### PR TITLE
Fix CI hanging on Git

### DIFF
--- a/.github/workflows/release_core.yml
+++ b/.github/workflows/release_core.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: passepartoutvpn/action-prepare-xcode-build@master
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
-          submodules: true
       - name: Run tests
         run: |
           swift test
@@ -25,7 +24,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.ACCESS_TOKEN }}
-          submodules: true
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "16"


### PR DESCRIPTION
Drop the HTTPS injection from https://github.com/passepartoutvpn/action-prepare-xcode-build/commit/1851b9adfd4c3540f367495ead7f577549bc8d49. The repository choices are now made with a conditional Package.swift