### PR TITLE
Validate Package.swift environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,9 @@ jobs:
           access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Use remote Core binary
         run: |
-          sed -i '' "s/environment = .remoteSource/environment = .remoteBinary/" "Package.swift"
+          default_env="environment = .remoteSource"
+          grep "^$default_env$" Package.swift
+          sed -i '' "s/^${default_env}$/environment = .remoteBinary/" Package.swift
       - name: Run tests
         run: |
           swift test

--- a/Package.swift
+++ b/Package.swift
@@ -14,9 +14,9 @@ enum Environment {
 }
 
 let environment: Environment
-environment = .remoteSource
+// environment = .remoteSource
 // environment = .remoteBinary
-// environment = .localSource
+environment = .localSource
 
 let binaryFilename = "PartoutCore.xcframework.zip"
 let version = "0.99.91"

--- a/Package.swift
+++ b/Package.swift
@@ -14,9 +14,9 @@ enum Environment {
 }
 
 let environment: Environment
-// environment = .remoteSource
+environment = .remoteSource
 // environment = .remoteBinary
-environment = .localSource
+// environment = .localSource
 
 let binaryFilename = "PartoutCore.xcframework.zip"
 let version = "0.99.91"


### PR DESCRIPTION
Avoid nasty things by ensuring that the committed environment for core is always .remoteSource