### PR TITLE
Assume on-demand enabled if module is enabled

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ environment = .remoteBinary
 let areas: Set<Area> = Set(Area.allCases)
 
 // action-release-binary-package (PartoutCore)
-let sha1 = "2d5fb2ef1cf07e557cfe541638469b2263323694"
+let sha1 = "7f606f4e69f26bc4427a25108e7f2940392f1acd"
 let binaryFilename = "PartoutCore.xcframework.zip"
 let version = "0.99.100"
 let checksum = "955651e7692023cffaafc52ea04f6513e8f6b40e70dff5a79b80bf3a6586230b"

--- a/Sources/Platforms/AppleNE/App/NETunnelStrategy.swift
+++ b/Sources/Platforms/AppleNE/App/NETunnelStrategy.swift
@@ -223,7 +223,7 @@ extension NETunnelStrategy: NETunnelManagerRepository {
                     } else {
                         $0.onDemandRules = [NEOnDemandRuleConnect()]
                     }
-                    shouldEnableOnDemand = onDemandModule.isEnabled
+                    shouldEnableOnDemand = true
                 } else {
                     shouldEnableOnDemand = false
                 }


### PR DESCRIPTION
Redundant field removed in [this PR](https://github.com/passepartoutvpn/partout-core/pull/543).