### PR TITLE
OpenVPN: Fix discarded routes from local .ovpn

### DIFF
--- a/Sources/OpenVPN/OpenVPNOpenSSL/Internal/NetworkSettingsBuilder.swift
+++ b/Sources/OpenVPN/OpenVPNOpenSSL/Internal/NetworkSettingsBuilder.swift
@@ -189,10 +189,8 @@ private extension NetworkSettingsBuilder {
         var target = allRoutes4
         target.insert(contentsOf: ipv4.includedRoutes, at: 0)
 
-        // FIXME: ###, if gateway == nil, inject ifconfig/route-gateway
-
         let routes: [Route] = target.compactMap { route in
-            let ipv4Route = Route(route.destination, route.gateway)
+            let ipv4Route = Route(route.destination, route.gateway ?? ipv4.defaultGateway)
             if route.destination == nil {
                 guard isIPv4Gateway, let gw = route.gateway else {
                     pp_log(.openvpn, .error, "\tIPv4: Ignored default route (not default gateway)")
@@ -217,10 +215,8 @@ private extension NetworkSettingsBuilder {
         var target = allRoutes6
         target.insert(contentsOf: ipv6.includedRoutes, at: 0)
 
-        // FIXME: ###, if gateway == nil, inject ifconfig-ipv6/route6-gateway
-
         let routes: [Route] = target.compactMap { route in
-            let ipv6Route = Route(route.destination, route.gateway)
+            let ipv6Route = Route(route.destination, route.gateway ?? ipv6.defaultGateway)
             if route.destination == nil {
                 guard isIPv6Gateway, let gw = route.gateway else {
                     pp_log(.openvpn, .error, "\tIPv6: Ignored default route (not default gateway)")

--- a/Sources/OpenVPN/OpenVPNOpenSSL/Internal/NetworkSettingsBuilder.swift
+++ b/Sources/OpenVPN/OpenVPNOpenSSL/Internal/NetworkSettingsBuilder.swift
@@ -190,7 +190,7 @@ private extension NetworkSettingsBuilder {
         target.insert(contentsOf: ipv4.includedRoutes, at: 0)
 
         let routes: [Route] = target.compactMap { route in
-            let ipv4Route = Route(route.destination, route.gateway ?? ipv4.defaultGateway)
+            let ipv4Route = Route(route.destination, route.gateway)
             if route.destination == nil {
                 guard isIPv4Gateway, let gw = route.gateway else {
                     pp_log(.openvpn, .error, "\tIPv4: Ignored default route (not default gateway)")
@@ -216,7 +216,7 @@ private extension NetworkSettingsBuilder {
         target.insert(contentsOf: ipv6.includedRoutes, at: 0)
 
         let routes: [Route] = target.compactMap { route in
-            let ipv6Route = Route(route.destination, route.gateway ?? ipv6.defaultGateway)
+            let ipv6Route = Route(route.destination, route.gateway)
             if route.destination == nil {
                 guard isIPv6Gateway, let gw = route.gateway else {
                     pp_log(.openvpn, .error, "\tIPv6: Ignored default route (not default gateway)")

--- a/Sources/OpenVPN/OpenVPNOpenSSL/Internal/NetworkSettingsBuilder.swift
+++ b/Sources/OpenVPN/OpenVPNOpenSSL/Internal/NetworkSettingsBuilder.swift
@@ -189,10 +189,13 @@ private extension NetworkSettingsBuilder {
         var target = allRoutes4
         target.insert(contentsOf: ipv4.includedRoutes, at: 0)
 
+        // FIXME: ###, if gateway == nil, inject ifconfig/route-gateway
+
         let routes: [Route] = target.compactMap { route in
             let ipv4Route = Route(route.destination, route.gateway)
             if route.destination == nil {
                 guard isIPv4Gateway, let gw = route.gateway else {
+                    pp_log(.openvpn, .error, "\tIPv4: Ignored default route (not default gateway)")
                     return nil
                 }
                 pp_log(.openvpn, .info, "\tIPv4: Set default gateway to \(gw)")
@@ -214,10 +217,13 @@ private extension NetworkSettingsBuilder {
         var target = allRoutes6
         target.insert(contentsOf: ipv6.includedRoutes, at: 0)
 
+        // FIXME: ###, if gateway == nil, inject ifconfig-ipv6/route6-gateway
+
         let routes: [Route] = target.compactMap { route in
             let ipv6Route = Route(route.destination, route.gateway)
             if route.destination == nil {
                 guard isIPv6Gateway, let gw = route.gateway else {
+                    pp_log(.openvpn, .error, "\tIPv6: Ignored default route (not default gateway)")
                     return nil
                 }
                 pp_log(.openvpn, .info, "\tIPv6: Set default gateway to \(gw)")

--- a/Sources/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParser+Builder.swift
+++ b/Sources/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParser+Builder.swift
@@ -679,9 +679,7 @@ extension StandardOpenVPNParser.Builder {
 
         builder.routes4 = try optRoutes4?.compactMap { tuple in
             let subnet = try Subnet(tuple.address, tuple.netmask)
-            guard let gateway = (tuple.gateway ?? defaultGateway4).map(Address.init(rawValue:)) ?? nil else {
-                return nil
-            }
+            let gateway = (tuple.gateway ?? defaultGateway4).map(Address.init(rawValue:)) ?? nil
             return Route(subnet, gateway)
         }
 
@@ -711,9 +709,7 @@ extension StandardOpenVPNParser.Builder {
 
         builder.routes6 = try optRoutes6?.compactMap { tuple in
             let subnet = try Subnet(tuple.destination, tuple.prefix)
-            guard let gateway = (tuple.gateway ?? defaultGateway6).map(Address.init(rawValue:)) ?? nil else {
-                return nil
-            }
+            let gateway = (tuple.gateway ?? defaultGateway6).map(Address.init(rawValue:)) ?? nil
             return Route(subnet, gateway)
         }
 

--- a/Tests/OpenVPN/OpenVPNOpenSSL/NetworkSettingsBuilderTests.swift
+++ b/Tests/OpenVPN/OpenVPNOpenSSL/NetworkSettingsBuilderTests.swift
@@ -168,11 +168,11 @@ final class NetworkSettingsBuilderTests: XCTestCase {
         XCTAssertEqual(sut.ipv6?.defaultGateway?.rawValue, "::6")
         XCTAssertEqual(sut.ipv4?.includedRoutes, [
             Route(nil, Address(rawValue: "6.6.6.6")),
-            Route(Subnet(rawValue: "50.50.50.50/24"), Address(rawValue: "6.6.6.6"))
+            Route(Subnet(rawValue: "50.50.50.50/24"), nil)
         ])
         XCTAssertEqual(sut.ipv6?.includedRoutes, [
             Route(nil, Address(rawValue: "::6")),
-            Route(Subnet(rawValue: "50:50::50/64"), Address(rawValue: "::6"))
+            Route(Subnet(rawValue: "50:50::50/64"), nil)
         ])
 
         remoteOptions.routingPolicies = []


### PR DESCRIPTION
Local routes were being discarded for not providing a gateway (often the case). Resolve the routes' gateway after merging with the remote options.