### PR TITLE
OpenVPN: Support inline auth-user-pass credentials

### DIFF
--- a/Sources/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParser+Builder.swift
+++ b/Sources/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParser+Builder.swift
@@ -46,6 +46,7 @@ extension StandardOpenVPNParser {
         private var optKeepAliveSeconds: TimeInterval?
         private var optKeepAliveTimeoutSeconds: TimeInterval?
         private var optRenegotiateAfterSeconds: TimeInterval?
+        private var optCredentials: OpenVPN.Credentials?
         //
         private var optDefaultProto: IPSocketType?
         private var optDefaultPort: UInt16?
@@ -142,6 +143,14 @@ extension StandardOpenVPNParser.Builder {
 
             // first is opening tag
             switch blockName {
+            case "auth-user-pass":
+                guard !currentBlock.isEmpty else {
+                    break
+                }
+                let username = currentBlock[0]
+                let password = currentBlock.count > 1 ? currentBlock[1] : ""
+                optCredentials = OpenVPN.Credentials.Builder(username: username, password: password).build()
+
             case "ca":
                 optCA = OpenVPN.CryptoContainer(pem: currentBlock.joined(separator: "\n"))
 
@@ -527,7 +536,7 @@ extension StandardOpenVPNParser.Builder {
 // MARK: - Building
 
 extension StandardOpenVPNParser.Builder {
-    func build(isClient: Bool, passphrase: String?) throws -> (configuration: OpenVPN.Configuration, warning: StandardOpenVPNParserError?) {
+    func build(isClient: Bool, passphrase: String?) throws -> (configuration: OpenVPN.Configuration, credentials: OpenVPN.Credentials?, warning: StandardOpenVPNParserError?) {
 
         // ensure that non-nil network settings also imply non-empty
         if let array = optRoutes4 {
@@ -771,7 +780,7 @@ extension StandardOpenVPNParser.Builder {
         //
 
         let configuration = try builder.tryBuild(isClient: isClient)
-        return (configuration, optWarning)
+        return (configuration, optCredentials, optWarning)
     }
 }
 

--- a/Sources/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParser+Builder.swift
+++ b/Sources/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParser+Builder.swift
@@ -536,7 +536,7 @@ extension StandardOpenVPNParser.Builder {
 // MARK: - Building
 
 extension StandardOpenVPNParser.Builder {
-    func build(isClient: Bool, passphrase: String?) throws -> (configuration: OpenVPN.Configuration, credentials: OpenVPN.Credentials?, warning: StandardOpenVPNParserError?) {
+    func build(isClient: Bool, passphrase: String?) throws -> StandardOpenVPNParser.Result {
 
         // ensure that non-nil network settings also imply non-empty
         if let array = optRoutes4 {
@@ -780,7 +780,12 @@ extension StandardOpenVPNParser.Builder {
         //
 
         let configuration = try builder.tryBuild(isClient: isClient)
-        return (configuration, optCredentials, optWarning)
+        return StandardOpenVPNParser.Result(
+            url: nil,
+            configuration: configuration,
+            credentials: optCredentials,
+            warning: optWarning
+        )
     }
 }
 

--- a/Sources/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParser+Option.swift
+++ b/Sources/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParser+Option.swift
@@ -37,11 +37,11 @@ extension StandardOpenVPNParser {
         // check blocks first
         case connectionBlock = "^<connection>"
 
-        case fragment = "^fragment"
-
         case connectionProxy = "^\\w+-proxy"
 
-        case externalFiles = "^(ca|cert|key|tls-auth|tls-crypt) "
+        case externalFiles = "^(auth-user-pass|ca|cert|key|tls-auth|tls-crypt) "
+
+        case fragment = "^fragment"
 
         // MARK: General
 

--- a/Sources/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParser+Option.swift
+++ b/Sources/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParser+Option.swift
@@ -37,11 +37,11 @@ extension StandardOpenVPNParser {
         // check blocks first
         case connectionBlock = "^<connection>"
 
+        case fragment = "^fragment"
+
         case connectionProxy = "^\\w+-proxy"
 
         case externalFiles = "^(auth-user-pass|ca|cert|key|tls-auth|tls-crypt) "
-
-        case fragment = "^fragment"
 
         // MARK: General
 

--- a/Sources/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParser.swift
+++ b/Sources/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParser.swift
@@ -64,6 +64,9 @@ public final class StandardOpenVPNParser {
         /// The overall parsed ``OpenVPN/Configuration``.
         public let configuration: OpenVPN.Configuration
 
+        /// The inline credentials.
+        public let credentials: OpenVPN.Credentials?
+
         /// Holds an optional `ConfigurationError` that didn't block the parser, but it would be worth taking care of.
         public let warning: StandardOpenVPNParserError?
     }
@@ -176,6 +179,7 @@ private extension StandardOpenVPNParser {
         return Result(
             url: originalURL,
             configuration: result.configuration,
+            credentials: result.credentials,
             warning: result.warning
         )
     }
@@ -196,7 +200,8 @@ extension StandardOpenVPNParser: ModuleImporter {
         do {
             let passphrase = object as? String
             let result = try parsed(fromContents: contents, passphrase: passphrase)
-            let builder = OpenVPNModule.Builder(configurationBuilder: result.configuration.builder())
+            var builder = OpenVPNModule.Builder(configurationBuilder: result.configuration.builder())
+            builder.credentials = result.credentials
             return try builder.tryBuild()
         } catch let error as StandardOpenVPNParserError {
             switch error {


### PR DESCRIPTION
[vpnd.io](https://github.com/passepartoutvpn/api-source/issues/36) generates .ovpn files with embedded credentials as a 2-line `<auth-user-pass>` block. Support it.