### PR TITLE
OpenVPN: Fix regression in ifconfig parsing

### DIFF
--- a/Sources/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParser+Builder.swift
+++ b/Sources/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParser+Builder.swift
@@ -688,7 +688,7 @@ extension StandardOpenVPNParser.Builder {
             }
             if let vpnNetwork4 = vpnAddress4.address.network(with: vpnMask4) {
                 let vpnDestination4 = try Subnet(vpnNetwork4.rawValue, vpnMask4)
-                includedRoutes.append(Route(vpnDestination4, vpnAddress4.address))
+                includedRoutes.append(Route(vpnDestination4, nil))
             }
 
             builder.ipv4 = IPSettings(subnet: vpnAddress4)
@@ -726,7 +726,7 @@ extension StandardOpenVPNParser.Builder {
             }
             if let vpnNetwork6 = vpnAddress6.address.network(with: vpnPrefix6) {
                 let vpnDestination6 = try Subnet(vpnNetwork6.rawValue, vpnPrefix6)
-                includedRoutes.append(Route(vpnDestination6, vpnAddress6.address))
+                includedRoutes.append(Route(vpnDestination6, nil))
             }
 
             builder.ipv6 = IPSettings(subnet: vpnAddress6)

--- a/Tests/OpenVPN/OpenVPNOpenSSL/PushReplyTests.swift
+++ b/Tests/OpenVPN/OpenVPNOpenSSL/PushReplyTests.swift
@@ -53,7 +53,7 @@ final class PushReplyTests: XCTestCase {
         reply.debug()
 
         XCTAssertEqual(reply.options.ipv4?.subnet?.address.rawValue, "10.5.10.6")
-        XCTAssertEqual(reply.options.ipv4?.subnet?.ipv4Mask, "255.255.255.255")
+        XCTAssertEqual(reply.options.ipv4?.subnet?.ipv4Mask, "255.255.255.252")
         XCTAssertEqual(reply.options.ipv4?.defaultGateway?.rawValue, "10.5.10.5")
         XCTAssertEqual(reply.options.dnsServers, ["209.222.18.222", "209.222.18.218"])
     }
@@ -67,7 +67,7 @@ final class PushReplyTests: XCTestCase {
         reply.debug()
 
         XCTAssertEqual(reply.options.ipv4?.subnet?.address.rawValue, "10.8.0.2")
-        XCTAssertEqual(reply.options.ipv4?.subnet?.ipv4Mask, "255.255.255.255")
+        XCTAssertEqual(reply.options.ipv4?.subnet?.ipv4Mask, "255.255.255.0")
         XCTAssertEqual(reply.options.ipv4?.defaultGateway?.rawValue, "10.8.0.1")
         XCTAssertEqual(reply.options.dnsServers, ["8.8.8.8", "4.4.4.4"])
     }
@@ -99,10 +99,10 @@ final class PushReplyTests: XCTestCase {
         reply.debug()
 
         XCTAssertEqual(reply.options.ipv4?.subnet?.address.rawValue, "10.8.0.2")
-        XCTAssertEqual(reply.options.ipv4?.subnet?.ipv4Mask, "255.255.255.255")
+        XCTAssertEqual(reply.options.ipv4?.subnet?.ipv4Mask, "255.255.255.0")
         XCTAssertEqual(reply.options.ipv4?.defaultGateway?.rawValue, "10.8.0.1")
         XCTAssertEqual(reply.options.ipv6?.subnet?.address.rawValue, "fe80::601:30ff:feb7:ec01")
-        XCTAssertEqual(reply.options.ipv6?.subnet?.prefixLength, 128)
+        XCTAssertEqual(reply.options.ipv6?.subnet?.prefixLength, 64)
         XCTAssertEqual(reply.options.ipv6?.defaultGateway?.rawValue, "fe80::601:30ff:feb7:dc02")
         XCTAssertEqual(reply.options.dnsServers, ["2001:4860:4860::8888", "2001:4860:4860::8844"])
     }

--- a/Tests/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParserTests.swift
+++ b/Tests/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParserTests.swift
@@ -183,13 +183,13 @@ final class StandardOpenVPNParserTests: XCTestCase {
 
         let pushReply = try XCTUnwrap(parser.pushReply(with: line))
 
-        XCTAssertEqual(pushReply.options.ipv4?.subnet, Subnet(rawValue: "172.31.2.6/32"))
+        XCTAssertEqual(pushReply.options.ipv4?.subnet, Subnet(rawValue: "172.31.2.6/24"))
         XCTAssertEqual(pushReply.options.ipv4?.includedRoutes, [
             Route(defaultWithGateway: Address(rawValue: "172.31.2.1")),
             Route(Subnet(rawValue: "172.31.2.0/24"), Address(rawValue: "172.31.2.6"))
         ])
 
-        XCTAssertEqual(pushReply.options.ipv6?.subnet, Subnet(rawValue: "1234::12/128"))
+        XCTAssertEqual(pushReply.options.ipv6?.subnet, Subnet(rawValue: "1234::12/10"))
         XCTAssertEqual(pushReply.options.ipv6?.includedRoutes, [
             Route(defaultWithGateway: Address(rawValue: "1234::1")),
             Route(Subnet(rawValue: "1200::/10"), Address(rawValue: "1234::12"))

--- a/Tests/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParserTests.swift
+++ b/Tests/OpenVPN/OpenVPNOpenSSL/StandardOpenVPNParserTests.swift
@@ -186,13 +186,13 @@ final class StandardOpenVPNParserTests: XCTestCase {
         XCTAssertEqual(pushReply.options.ipv4?.subnet, Subnet(rawValue: "172.31.2.6/24"))
         XCTAssertEqual(pushReply.options.ipv4?.includedRoutes, [
             Route(defaultWithGateway: Address(rawValue: "172.31.2.1")),
-            Route(Subnet(rawValue: "172.31.2.0/24"), Address(rawValue: "172.31.2.6"))
+            Route(Subnet(rawValue: "172.31.2.0/24"), nil)
         ])
 
         XCTAssertEqual(pushReply.options.ipv6?.subnet, Subnet(rawValue: "1234::12/10"))
         XCTAssertEqual(pushReply.options.ipv6?.includedRoutes, [
             Route(defaultWithGateway: Address(rawValue: "1234::1")),
-            Route(Subnet(rawValue: "1200::/10"), Address(rawValue: "1234::12"))
+            Route(Subnet(rawValue: "1200::/10"), nil)
         ])
     }
 }


### PR DESCRIPTION
Do not use /32 and /128 for the interface IP, revert to the provided prefix/netmask. Then omit the gateway, which is probably the real culprit. Including the route in the tunnel is enough. Route gateway behavior in NE is, honestly, still unclear to me.

Regression in #49