### PR TITLE
NE: Simplify some entities

### DIFF
--- a/Sources/Platforms/AppleNE/AppExtension/NEPTPForwarder.swift
+++ b/Sources/Platforms/AppleNE/AppExtension/NEPTPForwarder.swift
@@ -49,8 +49,7 @@ public actor NEPTPForwarder {
         factoryOptions: NEInterfaceFactory.Options = .init(),
         connectionOptions: ConnectionParameters.Options = .init(),
         stopDelay: Int = 2000,
-        reconnectionDelay: Int = 2000,
-        willStart: (@Sendable (Profile) async throws -> Void)? = nil
+        reconnectionDelay: Int = 2000
     ) {
         let environment = controller.environment
         let factory = NEInterfaceFactory(ctx, provider: controller.provider, options: factoryOptions)
@@ -70,8 +69,7 @@ public actor NEPTPForwarder {
             reachability: reachability,
             messageHandler: messageHandler,
             stopDelay: stopDelay,
-            reconnectionDelay: reconnectionDelay,
-            willStart: willStart
+            reconnectionDelay: reconnectionDelay
         )
 
         self.ctx = ctx

--- a/Sources/Platforms/AppleNE/AppExtension/NEPTPForwarder.swift
+++ b/Sources/Platforms/AppleNE/AppExtension/NEPTPForwarder.swift
@@ -51,7 +51,7 @@ public actor NEPTPForwarder {
         stopDelay: Int = 2000,
         reconnectionDelay: Int = 2000,
         willStart: (@Sendable (Profile) async throws -> Void)? = nil
-    ) async throws {
+    ) {
         let environment = controller.environment
         let factory = NEInterfaceFactory(ctx, provider: controller.provider, options: factoryOptions)
         let reachability = NEObservablePath(ctx)

--- a/Sources/Platforms/AppleNE/Connection/NETunnelController.swift
+++ b/Sources/Platforms/AppleNE/Connection/NETunnelController.swift
@@ -29,8 +29,6 @@ import PartoutCore
 
 /// Implementation of a `TunnelController` via `NEPacketTunnelProvider`.
 public final class NETunnelController: TunnelController {
-    private let ctx: PartoutContext
-
     public private(set) weak var provider: NEPacketTunnelProvider?
 
     public let registry: Registry
@@ -42,7 +40,6 @@ public final class NETunnelController: TunnelController {
     public let environment: TunnelEnvironment
 
     public init(
-        _ ctx: PartoutContext,
         provider: NEPacketTunnelProvider,
         decoder: NEProtocolDecoder,
         registry: Registry,
@@ -52,7 +49,6 @@ public final class NETunnelController: TunnelController {
         guard let tunnelConfiguration = provider.protocolConfiguration as? NETunnelProviderProtocol else {
             throw PartoutError(.decoding)
         }
-        self.ctx = ctx
         self.provider = provider
         self.registry = registry
         originalProfile = try decoder.profile(from: tunnelConfiguration)
@@ -67,16 +63,16 @@ public final class NETunnelController: TunnelController {
             return
         }
         let tunnelSettings = profile.networkSettings(with: info)
-        pp_log(ctx, .ne, .info, "Commit tunnel settings: \(tunnelSettings)")
+        pp_log_id(profile.id, .ne, .info, "Commit tunnel settings: \(tunnelSettings)")
         try await provider.setTunnelNetworkSettings(tunnelSettings)
     }
 
     public func clearTunnelSettings() async {
         do {
-            pp_log(ctx, .ne, .info, "Clear tunnel settings")
+            pp_log_id(profile.id, .ne, .info, "Clear tunnel settings")
             try await provider?.setTunnelNetworkSettings(nil)
         } catch {
-            pp_log(ctx, .ne, .error, "Unable to clear tunnel settings: \(error)")
+            pp_log_id(profile.id, .ne, .error, "Unable to clear tunnel settings: \(error)")
         }
     }
 
@@ -97,9 +93,9 @@ public final class NETunnelController: TunnelController {
             return
         }
         if let error {
-            pp_log(ctx, .ne, .fault, "Dispose tunnel: \(error)")
+            pp_log_id(profile.id, .ne, .fault, "Dispose tunnel: \(error)")
         } else {
-            pp_log(ctx, .ne, .notice, "Dispose tunnel")
+            pp_log_id(profile.id, .ne, .notice, "Dispose tunnel")
         }
         provider.cancelTunnelWithError(error)
     }
@@ -107,6 +103,6 @@ public final class NETunnelController: TunnelController {
 
 private extension NETunnelController {
     func logReleasedProvider() {
-        pp_log(ctx, .ne, .info, "NETunnelController: NEPacketTunnelProvider released")
+        pp_log_id(profile.id, .ne, .info, "NETunnelController: NEPacketTunnelProvider released")
     }
 }


### PR DESCRIPTION
- Use Profile.ID in NETunnelController to infer context
- Drop unused NEPTPForwarder.willStart()
- Drop unnecessary async throws from NEPTPForwarder