### PR TITLE
OpenVPN: Improve efficiency of XOR processing

### DIFF
--- a/Sources/OpenVPN/OpenVPNOpenSSL/Internal/XORProcessor.swift
+++ b/Sources/OpenVPN/OpenVPNOpenSSL/Internal/XORProcessor.swift
@@ -83,57 +83,39 @@ struct XORProcessor {
     func processPacket(_ packet: Data, outbound: Bool) -> Data {
         switch method {
         case .xormask(let mask):
-            return Self.xormask(packet: packet, mask: mask)
+            var dst = [UInt8](packet)
+            let dstLength = dst.count
+            dst.withUnsafeMutableBytes { dst in
+                xor_mask_legacy(dst.bytePointer, dst.bytePointer, dstLength, mask)
+            }
+            return Data(dst)
 
         case .xorptrpos:
-            return Self.xorptrpos(packet: packet)
+            var dst = [UInt8](packet)
+            let dstLength = dst.count
+            dst.withUnsafeMutableBytes { dst in
+                xor_ptrpos_legacy(dst.bytePointer, dst.bytePointer, dstLength)
+            }
+            return Data(dst)
 
         case .reverse:
-            return Self.reverse(packet: packet)
+            var dst = [UInt8](packet)
+            let dstLength = dst.count
+            dst.withUnsafeMutableBytes { dst in
+                xor_reverse_legacy(dst.bytePointer, dst.bytePointer, dstLength)
+            }
+            return Data(dst)
 
         case .obfuscate(let mask):
-            return Self.obfuscate(packet: packet, mask: mask, outbound: outbound)
+            var dst = [UInt8](packet)
+            let dstLength = dst.count
+            dst.withUnsafeMutableBytes { dst in
+                xor_obfuscate_legacy(dst.bytePointer, dst.bytePointer, dstLength, mask, outbound)
+            }
+            return Data(dst)
 
         @unknown default:
             return packet
         }
-    }
-}
-
-private extension XORProcessor {
-    static func xormask(packet: Data, mask: ZeroingData) -> Data {
-        var dst = [UInt8](packet)
-        let dstLength = dst.count
-        dst.withUnsafeMutableBytes { dst in
-            xor_mask_legacy(dst.bytePointer, dst.bytePointer, dstLength, mask)
-        }
-        return Data(dst)
-    }
-
-    static func xorptrpos(packet: Data) -> Data {
-        var dst = [UInt8](packet)
-        let dstLength = dst.count
-        dst.withUnsafeMutableBytes { dst in
-            xor_ptrpos_legacy(dst.bytePointer, dst.bytePointer, dstLength)
-        }
-        return Data(dst)
-    }
-
-    static func reverse(packet: Data) -> Data {
-        var dst = [UInt8](packet)
-        let dstLength = dst.count
-        dst.withUnsafeMutableBytes { dst in
-            xor_reverse_legacy(dst.bytePointer, dst.bytePointer, dstLength)
-        }
-        return Data(dst)
-    }
-
-    static func obfuscate(packet: Data, mask: ZeroingData, outbound: Bool) -> Data {
-        var dst = [UInt8](packet)
-        let dstLength = dst.count
-        dst.withUnsafeMutableBytes { dst in
-            xor_obfuscate_legacy(dst.bytePointer, dst.bytePointer, dstLength, mask, outbound)
-        }
-        return Data(dst)
     }
 }

--- a/Sources/OpenVPN/OpenVPNOpenSSL/Internal/XORProcessor.swift
+++ b/Sources/OpenVPN/OpenVPNOpenSSL/Internal/XORProcessor.swift
@@ -81,41 +81,29 @@ struct XORProcessor {
      - Returns: The packet after XOR processing.
      **/
     func processPacket(_ packet: Data, outbound: Bool) -> Data {
+        var dst = [UInt8](packet)
+        let dstLength = dst.count
         switch method {
         case .xormask(let mask):
-            var dst = [UInt8](packet)
-            let dstLength = dst.count
             dst.withUnsafeMutableBytes { dst in
                 xor_mask_legacy(dst.bytePointer, dst.bytePointer, dstLength, mask)
             }
-            return Data(dst)
-
         case .xorptrpos:
-            var dst = [UInt8](packet)
-            let dstLength = dst.count
             dst.withUnsafeMutableBytes { dst in
                 xor_ptrpos_legacy(dst.bytePointer, dst.bytePointer, dstLength)
             }
-            return Data(dst)
-
         case .reverse:
-            var dst = [UInt8](packet)
-            let dstLength = dst.count
             dst.withUnsafeMutableBytes { dst in
                 xor_reverse_legacy(dst.bytePointer, dst.bytePointer, dstLength)
             }
-            return Data(dst)
-
         case .obfuscate(let mask):
-            var dst = [UInt8](packet)
-            let dstLength = dst.count
             dst.withUnsafeMutableBytes { dst in
                 xor_obfuscate_legacy(dst.bytePointer, dst.bytePointer, dstLength, mask, outbound)
             }
-            return Data(dst)
-
         @unknown default:
-            return packet
+            assertionFailure("Unhandled XOR method: \(method)")
+            break
         }
+        return Data(dst)
     }
 }

--- a/Sources/OpenVPN/OpenVPNOpenSSL_ObjC/include/XOR.h
+++ b/Sources/OpenVPN/OpenVPNOpenSSL_ObjC/include/XOR.h
@@ -27,28 +27,34 @@
 
 #import "XORMethodNative.h"
 
-static inline void xor_mask_legacy(uint8_t *dst, const uint8_t *src, ZeroingData *xorMask, size_t length)
+static inline
+void xor_mask_legacy(uint8_t *dst,
+                     const uint8_t *src,
+                     size_t srcLength,
+                     ZeroingData *xorMask)
 {
-    if (xorMask.length > 0) {
-        for (size_t i = 0; i < length; ++i) {
-            dst[i] = src[i] ^ ((uint8_t *)(xorMask.bytes))[i % xorMask.length];
-        }
+    assert(xorMask);
+    if (!xorMask || xorMask.length == 0) {
         return;
     }
-    memcpy(dst, src, length);
+    for (size_t i = 0; i < srcLength; ++i) {
+        dst[i] = src[i] ^ ((uint8_t *)(xorMask.bytes))[i % xorMask.length];
+    }
 }
 
-static inline void xor_ptrpos_legacy(uint8_t *dst, const uint8_t *src, size_t length)
+static inline
+void xor_ptrpos_legacy(uint8_t *dst, const uint8_t *src, size_t srcLength)
 {
-    for (size_t i = 0; i < length; ++i) {
+    for (size_t i = 0; i < srcLength; ++i) {
         dst[i] = src[i] ^ (i + 1);
     }
 }
 
-static inline void xor_reverse_legacy(uint8_t *dst, const uint8_t *src, size_t length)
+static inline
+void xor_reverse_legacy(uint8_t *dst, const uint8_t *src, size_t srcLength)
 {
     size_t start = 1;
-    size_t end = length - 1;
+    size_t end = srcLength - 1;
     uint8_t temp = 0;
     dst[0] = src[0];
     while (start < end) {
@@ -63,38 +69,45 @@ static inline void xor_reverse_legacy(uint8_t *dst, const uint8_t *src, size_t l
     }
 }
 
-static inline void xor_memcpy_legacy(uint8_t *dst, NSData *src, XORMethodNative method, ZeroingData *mask, BOOL outbound)
+static inline
+void xor_obfuscate_legacy(uint8_t *dst, const uint8_t *src, size_t srcLength, ZeroingData *mask, BOOL outbound)
 {
-    const uint8_t *source = (uint8_t *)src.bytes;
+    if (outbound) {
+        xor_ptrpos_legacy(dst, src, srcLength);
+        xor_reverse_legacy(dst, dst, srcLength);
+        xor_ptrpos_legacy(dst, dst, srcLength);
+        xor_mask_legacy(dst, dst, srcLength, mask);
+    } else {
+        xor_mask_legacy(dst, src, srcLength, mask);
+        xor_ptrpos_legacy(dst, dst, srcLength);
+        xor_reverse_legacy(dst, dst, srcLength);
+        xor_ptrpos_legacy(dst, dst, srcLength);
+    }
+}
+
+static inline
+void xor_memcpy_legacy(uint8_t *dst, NSData *srcData, XORMethodNative method, ZeroingData *mask, BOOL outbound)
+{
+    const uint8_t *src = srcData.bytes;
     switch (method) {
         case XORMethodNativeNone:
-            memcpy(dst, source, src.length);
+            memcpy(dst, src, srcData.length);
             break;
 
         case XORMethodNativeMask:
-            xor_mask_legacy(dst, source, mask, src.length);
+            xor_mask_legacy(dst, src, srcData.length, mask);
             break;
 
         case XORMethodNativePtrPos:
-            xor_ptrpos_legacy(dst, source, src.length);
+            xor_ptrpos_legacy(dst, src, srcData.length);
             break;
 
         case XORMethodNativeReverse:
-            xor_reverse_legacy(dst, source, src.length);
+            xor_reverse_legacy(dst, src, srcData.length);
             break;
 
         case XORMethodNativeObfuscate:
-            if (outbound) {
-                xor_ptrpos_legacy(dst, source, src.length);
-                xor_reverse_legacy(dst, dst, src.length);
-                xor_ptrpos_legacy(dst, dst, src.length);
-                xor_mask_legacy(dst, dst, mask, src.length);
-            } else {
-                xor_mask_legacy(dst, source, mask, src.length);
-                xor_ptrpos_legacy(dst, dst, src.length);
-                xor_reverse_legacy(dst, dst, src.length);
-                xor_ptrpos_legacy(dst, dst, src.length);
-            }
+            xor_obfuscate_legacy(dst, src, srcData.length, mask, outbound);
             break;
     }
 }

--- a/Sources/OpenVPN/OpenVPNOpenSSL_ObjC/include/XOR.h
+++ b/Sources/OpenVPN/OpenVPNOpenSSL_ObjC/include/XOR.h
@@ -46,7 +46,7 @@ static inline
 void xor_ptrpos_legacy(uint8_t *dst, const uint8_t *src, size_t srcLength)
 {
     for (size_t i = 0; i < srcLength; ++i) {
-        dst[i] = src[i] ^ (i + 1);
+        dst[i] = src[i] ^ ((i + 1) & 0xff);
     }
 }
 

--- a/Tests/OpenVPN/OpenVPNOpenSSL/XORProcessorTests.swift
+++ b/Tests/OpenVPN/OpenVPNOpenSSL/XORProcessorTests.swift
@@ -33,6 +33,84 @@ final class XORProcessorTests: XCTestCase {
 
     private let mask = SecureData("f76dab30")!
 
+    func test_givenProcessor_whenMask_thenIsExpected() {
+        let sut = XORProcessor(method: .xormask(mask: mask))
+        let data = prng.data(length: 10)
+        let maskData = mask.zData
+        let processed = sut.processPacket(data, outbound: false)
+        print(data.toHex())
+        print(processed.toHex())
+        for (i, byte) in processed.enumerated() {
+            XCTAssertEqual(byte, data[i] ^ maskData.bytes[i % maskData.length])
+        }
+    }
+
+    func test_givenProcessor_whenPtrPos_thenIsExpected() {
+        let sut = XORProcessor(method: .xorptrpos)
+        let data = prng.data(length: 10)
+        let processed = sut.processPacket(data, outbound: false)
+        print(data.toHex())
+        print(processed.toHex())
+        for (i, byte) in processed.enumerated() {
+            XCTAssertEqual(byte, data[i] ^ UInt8((i + 1) & 0xff))
+        }
+    }
+
+    func test_givenProcessor_whenReverse_thenIsExpected() {
+        let sut = XORProcessor(method: .reverse)
+        var data = prng.data(length: 10)
+        var processed = sut.processPacket(data, outbound: false)
+        print(data.toHex())
+        print(processed.toHex())
+
+        XCTAssertEqual(processed[0], data[0])
+        data.removeFirst()
+        processed.removeFirst()
+        print(data.toHex())
+        print(processed.toHex())
+        assert(data.count == 9)
+        assert(processed.count == 9)
+        XCTAssertEqual(processed, Data(data.reversed()))
+
+//        // this crashes as if it returned pre-removeFirst() offsets, bug in Data?
+//        for (i, byte) in processed.enumerated() {
+//            XCTAssertEqual(byte, data[data.count - i - 1])
+//        }
+//
+//        // this crashes for the same reason
+//        for (i, byte) in processed.reversed().enumerated() {
+//            XCTAssertEqual(byte, data[i])
+//        }
+    }
+
+    func test_givenProcessor_whenObfuscateOutbound_thenIsExpected() {
+        let sut = XORProcessor(method: .obfuscate(mask: mask))
+        let data = Data(hex: "832ae7598dfa0378bc19")
+        let processed = sut.processPacket(data, outbound: true)
+        let expected = Data(hex: "e52680106098bc658b15")
+
+        // original = "832ae7598dfa0378bc19"
+        // ptrpos   = "8228e45d88fc0470b513"
+        // reverse  = "8213b57004fc885de428"
+        // ptrpos   = "8311b67401fa8f55ed22"
+        // mask     = "e52680106098bc658b15"
+
+        print(data.toHex())
+        print(processed.toHex())
+        XCTAssertEqual(processed, expected)
+    }
+
+    func test_givenProcessor_whenObfuscateInbound_thenIsExpected() {
+        let sut = XORProcessor(method: .obfuscate(mask: mask))
+        let data = Data(hex: "e52680106098bc658b15")
+        let processed = sut.processPacket(data, outbound: false)
+        let expected = Data(hex: "832ae7598dfa0378bc19")
+
+        print(data.toHex())
+        print(processed.toHex())
+        XCTAssertEqual(processed, expected)
+    }
+
     func test_givenProcessor_whenMaskthenIsReversible() {
         let sut = XORProcessor(method: .xormask(mask: mask))
         sut.assertReversible(prng.data(length: 1000))


### PR DESCRIPTION
XORProcessor is utterly dumb:

- Do not copy mask on EACH packet! (.zData is crazy expensive in this context)
- Perform XOR in-place
- Use C functions directly
- Drop redundant memcpy() in xor_mask