### PR TITLE
OpenVPN/Cross: Fix condition for detecting ping packets

### DIFF
--- a/Sources/OpenVPN/OpenVPN_C/include/openvpn/packet.h
+++ b/Sources/OpenVPN/OpenVPN_C/include/openvpn/packet.h
@@ -82,7 +82,7 @@ bool packet_is_ping(const uint8_t *_Nonnull bytes, size_t len) {
         0x2a, 0x18, 0x7b, 0xf3, 0x64, 0x1e, 0xb4, 0xcb,
         0x07, 0xed, 0x2d, 0x0a, 0x98, 0x1f, 0xc7, 0x48
     };
-    return memcmp(bytes, ping, len) == 0;
+    return len == sizeof(ping) && !memcmp(bytes, ping, len);
 }
 
 static inline


### PR DESCRIPTION
Only checking the prefix, so any packet:

- With len <= sizeof(ping)
- Matching the ping string bytes up to len

was passing the ping/keep-alive test.

Fixes #99