### PR TITLE
Fix unsafe use of .withCString in hmac()

### DIFF
--- a/Sources/Crypto/OpenSSL_C/keys.c
+++ b/Sources/Crypto/OpenSSL_C/keys.c
@@ -50,6 +50,9 @@ size_t key_hmac_do(key_hmac_ctx *ctx) {
     assert(ctx->dst->length >= KeyHMACMaxLength);
 
     const EVP_MD *md = EVP_get_digestbyname(ctx->digest_name);
+    if (!md) {
+        return 0;
+    }
     unsigned int dst_len = 0;
     const bool success = HMAC(md,
                               ctx->secret->bytes,

--- a/Sources/OpenVPN/OpenVPN_Cross/Internal/CZeroingData+HMAC.swift
+++ b/Sources/OpenVPN/OpenVPN_Cross/Internal/CZeroingData+HMAC.swift
@@ -36,15 +36,15 @@ extension CZeroingData {
         secret: CZeroingData,
         data: CZeroingData
     ) throws -> CZeroingData {
-        var ctx = digestName.withCString { cDigest in
-            key_hmac_ctx(
+        let hmacLength = digestName.withCString { cDigest in
+            var ctx = key_hmac_ctx(
                 dst: ptr,
                 digest_name: cDigest,
                 secret: secret.ptr,
                 data: data.ptr
             )
+            return key_hmac_do(&ctx)
         }
-        let hmacLength = key_hmac_do(&ctx);
         guard hmacLength > 0 else {
             throw CryptoError.hmac
         }


### PR DESCRIPTION
Fixes #110 