### PR TITLE
Improve robustness of C crypto

### DIFF
--- a/Sources/Crypto/Core_C/include/crypto/allocation.h
+++ b/Sources/Crypto/Core_C/include/crypto/allocation.h
@@ -37,9 +37,15 @@
 #pragma once
 
 #include <assert.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+static inline
+void pp_assert(bool condition) {
+    assert(condition);
+}
 
 static inline
 void *_Nonnull pp_alloc_crypto(size_t size) {

--- a/Sources/Crypto/Core_C/include/crypto/crypto.h
+++ b/Sources/Crypto/Core_C/include/crypto/crypto.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "crypto/allocation.h"
 #include "crypto/zeroing_data.h"
 
 typedef enum {

--- a/Sources/Crypto/Core_C/include/crypto/crypto.h
+++ b/Sources/Crypto/Core_C/include/crypto/crypto.h
@@ -169,7 +169,7 @@ bool crypto_verify(crypto_ctx _Nonnull ctx,
                    const uint8_t *_Nonnull in, size_t in_len,
                    crypto_error_code *_Nullable error) {
 
-    assert(ctx->base.decrypter.verify);
+    pp_assert(ctx->base.decrypter.verify);
     return ctx->base.decrypter.verify(&ctx->base, in, in_len, error);
 }
 

--- a/Sources/Crypto/Core_C/include/crypto/crypto.h
+++ b/Sources/Crypto/Core_C/include/crypto/crypto.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <assert.h>
 #include "crypto/zeroing_data.h"
 
 typedef enum {

--- a/Sources/Crypto/Core_C/tls.c
+++ b/Sources/Crypto/Core_C/tls.c
@@ -37,7 +37,7 @@ tls_channel_options *_Nonnull tls_channel_options_create(int sec_level,
                                                          const char *_Nullable hostname,
                                                          void (*_Nonnull on_verify_failure)()) {
 
-    assert(ca_path && on_verify_failure);
+    pp_assert(ca_path && on_verify_failure);
 
     tls_channel_options *opt = pp_alloc_crypto(sizeof(tls_channel_options));
     opt->sec_level = sec_level;

--- a/Sources/Crypto/Core_C/tls.c
+++ b/Sources/Crypto/Core_C/tls.c
@@ -23,7 +23,6 @@
 //  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
 #include "crypto/allocation.h"
 #include "crypto/tls.h"
 

--- a/Sources/Crypto/Core_C/zeroing_data.c
+++ b/Sources/Crypto/Core_C/zeroing_data.c
@@ -92,12 +92,12 @@ void zd_free(zeroing_data_t *zd) {
 // MARK: Copy
 
 zeroing_data_t *zd_make_copy(const zeroing_data_t *zd) {
-    assert(zd);
+    pp_assert(zd);
     return zd_create_copy(zd->bytes, zd->length);
 }
 
 zeroing_data_t *zd_make_slice(const zeroing_data_t *zd, size_t offset, size_t length) {
-    assert(zd);
+    pp_assert(zd);
     if (offset + length > zd->length) return NULL;
 
     zeroing_data_t *slice = pp_alloc_crypto(sizeof(zeroing_data_t));
@@ -110,7 +110,7 @@ zeroing_data_t *zd_make_slice(const zeroing_data_t *zd, size_t offset, size_t le
 // MARK: Side effect
 
 void zd_append(zeroing_data_t *zd, const zeroing_data_t *other) {
-    assert(zd);
+    pp_assert(zd);
     size_t new_len = zd->length + other->length;
     uint8_t *new_bytes = pp_alloc_crypto(new_len);
     memcpy(new_bytes, zd->bytes, zd->length);
@@ -123,7 +123,7 @@ void zd_append(zeroing_data_t *zd, const zeroing_data_t *other) {
 }
 
 void zd_resize(zeroing_data_t *zd, size_t new_length) {
-    assert(zd);
+    pp_assert(zd);
     if (new_length == zd->length) return;
 
     uint8_t *new_bytes = pp_alloc_crypto(new_length);
@@ -141,7 +141,7 @@ void zd_resize(zeroing_data_t *zd, size_t new_length) {
 }
 
 void zd_remove_until(zeroing_data_t *zd, size_t offset) {
-    assert(zd);
+    pp_assert(zd);
     if (offset > zd->length) return;
 
     size_t new_length = zd->length - offset;
@@ -156,14 +156,14 @@ void zd_remove_until(zeroing_data_t *zd, size_t offset) {
 }
 
 void zd_zero(zeroing_data_t *zd) {
-    assert(zd);
+    pp_assert(zd);
     pp_zero(zd->bytes, zd->length);
 }
 
 // MARK: Accessors
 
 uint16_t zd_uint16(const zeroing_data_t *zd, size_t offset) {
-    assert(zd);
+    pp_assert(zd);
     if (offset + 2 > zd->length) return 0;
     return zd->bytes[offset] | (zd->bytes[offset + 1] << 8);
 }

--- a/Sources/Crypto/OpenSSL_C/crypto_aead.c
+++ b/Sources/Crypto/OpenSSL_C/crypto_aead.c
@@ -90,15 +90,14 @@ size_t local_encrypt(void *vctx,
 
     memcpy(ctx->iv_enc, flags->iv, (size_t)MIN(flags->iv_len, ctx->cipher_iv_len));
 
-    CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_CipherInit(ossl, NULL, NULL, ctx->iv_enc, -1);
-    CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_CipherUpdate(ossl, NULL, &tmp, flags->ad, (int)flags->ad_len);
-    CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_CipherUpdate(ossl, out + ctx->tag_len, &l1, in, (int)in_len);
-    CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_CipherFinal_ex(ossl, out + ctx->tag_len + l1, &l2);
-    CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_CIPHER_CTX_ctrl(ossl, EVP_CTRL_GCM_GET_TAG, (int)ctx->tag_len, out);
+    CRYPTO_CHECK(EVP_CipherInit(ossl, NULL, NULL, ctx->iv_enc, -1))
+    CRYPTO_CHECK(EVP_CipherUpdate(ossl, NULL, &tmp, flags->ad, (int)flags->ad_len))
+    CRYPTO_CHECK(EVP_CipherUpdate(ossl, out + ctx->tag_len, &l1, in, (int)in_len))
+    CRYPTO_CHECK(EVP_CipherFinal_ex(ossl, out + ctx->tag_len + l1, &l2))
+    CRYPTO_CHECK(EVP_CIPHER_CTX_ctrl(ossl, EVP_CTRL_GCM_GET_TAG, (int)ctx->tag_len, out))
 
     const size_t out_len = ctx->tag_len + l1 + l2;
-
-    CRYPTO_OPENSSL_RETURN_LENGTH(code, out_len, CryptoErrorEncryption)
+    return out_len;
 }
 
 static
@@ -132,15 +131,14 @@ size_t local_decrypt(void *vctx,
 
     memcpy(ctx->iv_dec, flags->iv, (size_t)MIN(flags->iv_len, ctx->cipher_iv_len));
 
-    CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_CipherInit(ossl, NULL, NULL, ctx->iv_dec, -1);
-    CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_CIPHER_CTX_ctrl(ossl, EVP_CTRL_GCM_SET_TAG, (int)ctx->tag_len, (void *)in);
-    CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_CipherUpdate(ossl, NULL, &tmp, flags->ad, (int)flags->ad_len);
-    CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_CipherUpdate(ossl, out, &l1, in + ctx->tag_len, (int)(in_len - ctx->tag_len));
-    CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_CipherFinal_ex(ossl, out + l1, &l2);
+    CRYPTO_CHECK(EVP_CipherInit(ossl, NULL, NULL, ctx->iv_dec, -1))
+    CRYPTO_CHECK(EVP_CIPHER_CTX_ctrl(ossl, EVP_CTRL_GCM_SET_TAG, (int)ctx->tag_len, (void *)in))
+    CRYPTO_CHECK(EVP_CipherUpdate(ossl, NULL, &tmp, flags->ad, (int)flags->ad_len))
+    CRYPTO_CHECK(EVP_CipherUpdate(ossl, out, &l1, in + ctx->tag_len, (int)(in_len - ctx->tag_len)))
+    CRYPTO_CHECK(EVP_CipherFinal_ex(ossl, out + l1, &l2))
 
     const size_t out_len = l1 + l2;
-
-    CRYPTO_OPENSSL_RETURN_LENGTH(code, out_len, CryptoErrorEncryption)
+    return out_len;
 }
 
 // MARK: -

--- a/Sources/Crypto/OpenSSL_C/crypto_aead.c
+++ b/Sources/Crypto/OpenSSL_C/crypto_aead.c
@@ -64,9 +64,8 @@ void local_configure_encrypt(void *vctx,
     pp_assert(cipher_key && cipher_key->length >= ctx->crypto.meta.cipher_key_len);
     pp_assert(hmac_key);
 
-    EVP_CIPHER_CTX_reset(ctx->ctx_enc);
-    EVP_CipherInit(ctx->ctx_enc, ctx->cipher, cipher_key->bytes, NULL, 1);
-
+    CRYPTO_ASSERT(EVP_CIPHER_CTX_reset(ctx->ctx_enc))
+    CRYPTO_ASSERT(EVP_CipherInit(ctx->ctx_enc, ctx->cipher, cipher_key->bytes, NULL, 1))
     local_prepare_iv(ctx, ctx->iv_enc, hmac_key);
 }
 
@@ -105,9 +104,8 @@ void local_configure_decrypt(void *vctx,
     pp_assert(cipher_key && cipher_key->length >= ctx->crypto.meta.cipher_key_len);
     pp_assert(hmac_key);
 
-    EVP_CIPHER_CTX_reset(ctx->ctx_dec);
-    EVP_CipherInit(ctx->ctx_dec, ctx->cipher, cipher_key->bytes, NULL, 0);
-
+    CRYPTO_ASSERT(EVP_CIPHER_CTX_reset(ctx->ctx_dec))
+    CRYPTO_ASSERT(EVP_CipherInit(ctx->ctx_dec, ctx->cipher, cipher_key->bytes, NULL, 0))
     local_prepare_iv(ctx, ctx->iv_dec, hmac_key);
 }
 

--- a/Sources/Crypto/OpenSSL_C/crypto_aead.c
+++ b/Sources/Crypto/OpenSSL_C/crypto_aead.c
@@ -33,16 +33,13 @@
 typedef struct {
     crypto_t crypto;
 
+    // cipher
     const EVP_CIPHER *_Nonnull cipher;
-    size_t cipher_key_len;
-    size_t cipher_iv_len;
-    size_t tag_len;
-    size_t id_len;
-
     EVP_CIPHER_CTX *_Nonnull ctx_enc;
     EVP_CIPHER_CTX *_Nonnull ctx_dec;
     uint8_t *_Nonnull iv_enc;
     uint8_t *_Nonnull iv_dec;
+    size_t id_len;
 } crypto_aead_ctx;
 
 static inline
@@ -50,13 +47,13 @@ void local_prepare_iv(const void *vctx, uint8_t *_Nonnull iv, const zeroing_data
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
     pp_assert(ctx);
     bzero(iv, ctx->id_len);
-    memcpy(iv + ctx->id_len, hmac_key->bytes, ctx->cipher_iv_len - ctx->id_len);
+    memcpy(iv + ctx->id_len, hmac_key->bytes, ctx->crypto.meta.cipher_iv_len - ctx->id_len);
 }
 
 size_t local_encryption_capacity(const void *vctx, size_t len) {
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
     pp_assert(ctx);
-    return pp_alloc_crypto_capacity(len, ctx->tag_len);
+    return pp_alloc_crypto_capacity(len, ctx->crypto.meta.tag_len);
 }
 
 static
@@ -64,7 +61,7 @@ void local_configure_encrypt(void *vctx,
                              const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
     pp_assert(ctx);
-    pp_assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
+    pp_assert(cipher_key && cipher_key->length >= ctx->crypto.meta.cipher_key_len);
     pp_assert(hmac_key);
 
     EVP_CIPHER_CTX_reset(ctx->ctx_enc);
@@ -88,15 +85,15 @@ size_t local_encrypt(void *vctx,
     EVP_CIPHER_CTX *ossl = ctx->ctx_enc;
     int l1 = 0, l2 = 0, tmp = 0, code = 1;
 
-    memcpy(ctx->iv_enc, flags->iv, (size_t)MIN(flags->iv_len, ctx->cipher_iv_len));
+    memcpy(ctx->iv_enc, flags->iv, (size_t)MIN(flags->iv_len, ctx->crypto.meta.cipher_iv_len));
 
     CRYPTO_CHECK(EVP_CipherInit(ossl, NULL, NULL, ctx->iv_enc, -1))
     CRYPTO_CHECK(EVP_CipherUpdate(ossl, NULL, &tmp, flags->ad, (int)flags->ad_len))
-    CRYPTO_CHECK(EVP_CipherUpdate(ossl, out + ctx->tag_len, &l1, in, (int)in_len))
-    CRYPTO_CHECK(EVP_CipherFinal_ex(ossl, out + ctx->tag_len + l1, &l2))
-    CRYPTO_CHECK(EVP_CIPHER_CTX_ctrl(ossl, EVP_CTRL_GCM_GET_TAG, (int)ctx->tag_len, out))
+    CRYPTO_CHECK(EVP_CipherUpdate(ossl, out + ctx->crypto.meta.tag_len, &l1, in, (int)in_len))
+    CRYPTO_CHECK(EVP_CipherFinal_ex(ossl, out + ctx->crypto.meta.tag_len + l1, &l2))
+    CRYPTO_CHECK(EVP_CIPHER_CTX_ctrl(ossl, EVP_CTRL_GCM_GET_TAG, (int)ctx->crypto.meta.tag_len, out))
 
-    const size_t out_len = ctx->tag_len + l1 + l2;
+    const size_t out_len = ctx->crypto.meta.tag_len + l1 + l2;
     return out_len;
 }
 
@@ -105,7 +102,7 @@ void local_configure_decrypt(void *vctx,
                              const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
     pp_assert(ctx);
-    pp_assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
+    pp_assert(cipher_key && cipher_key->length >= ctx->crypto.meta.cipher_key_len);
     pp_assert(hmac_key);
 
     EVP_CIPHER_CTX_reset(ctx->ctx_dec);
@@ -129,12 +126,12 @@ size_t local_decrypt(void *vctx,
     EVP_CIPHER_CTX *ossl = ctx->ctx_dec;
     int l1 = 0, l2 = 0, tmp = 0, code = 1;
 
-    memcpy(ctx->iv_dec, flags->iv, (size_t)MIN(flags->iv_len, ctx->cipher_iv_len));
+    memcpy(ctx->iv_dec, flags->iv, (size_t)MIN(flags->iv_len, ctx->crypto.meta.cipher_iv_len));
 
     CRYPTO_CHECK(EVP_CipherInit(ossl, NULL, NULL, ctx->iv_dec, -1))
-    CRYPTO_CHECK(EVP_CIPHER_CTX_ctrl(ossl, EVP_CTRL_GCM_SET_TAG, (int)ctx->tag_len, (void *)in))
+    CRYPTO_CHECK(EVP_CIPHER_CTX_ctrl(ossl, EVP_CTRL_GCM_SET_TAG, (int)ctx->crypto.meta.tag_len, (void *)in))
     CRYPTO_CHECK(EVP_CipherUpdate(ossl, NULL, &tmp, flags->ad, (int)flags->ad_len))
-    CRYPTO_CHECK(EVP_CipherUpdate(ossl, out, &l1, in + ctx->tag_len, (int)(in_len - ctx->tag_len)))
+    CRYPTO_CHECK(EVP_CipherUpdate(ossl, out, &l1, in + ctx->crypto.meta.tag_len, (int)(in_len - ctx->crypto.meta.tag_len)))
     CRYPTO_CHECK(EVP_CipherFinal_ex(ossl, out + l1, &l2))
 
     const size_t out_len = l1 + l2;
@@ -143,33 +140,37 @@ size_t local_decrypt(void *vctx,
 
 // MARK: -
 
-crypto_ctx crypto_aead_create(const char *cipher_name, size_t tag_len, size_t id_len,
+crypto_ctx crypto_aead_create(const char *cipher_name,
+                              size_t tag_len, size_t id_len,
                               const crypto_keys_t *keys) {
     pp_assert(cipher_name);
 
-    const EVP_CIPHER *cipher = EVP_get_cipherbyname(cipher_name);
-    if (!cipher) {
-        return NULL;
+    crypto_aead_ctx *ctx = pp_alloc_crypto(sizeof(crypto_aead_ctx));
+    ctx->cipher = EVP_get_cipherbyname(cipher_name);
+    if (!ctx->cipher) {
+        goto failure;
+    }
+    ctx->ctx_enc = EVP_CIPHER_CTX_new();
+    if (!ctx->ctx_enc) {
+        goto failure;
+    }
+    ctx->ctx_dec = EVP_CIPHER_CTX_new();
+    if (!ctx->ctx_dec) {
+        goto failure;
     }
 
-    crypto_aead_ctx *ctx = pp_alloc_crypto(sizeof(crypto_aead_ctx));
-    ctx->cipher = cipher;
-    ctx->tag_len = tag_len;
-    ctx->id_len = id_len;
-    ctx->cipher_key_len = EVP_CIPHER_key_length(cipher);
-    ctx->cipher_iv_len = EVP_CIPHER_iv_length(cipher);
+    // no longer fails
 
-    ctx->ctx_enc = EVP_CIPHER_CTX_new();
-    ctx->ctx_dec = EVP_CIPHER_CTX_new();
-    ctx->iv_enc = pp_alloc_crypto(ctx->cipher_iv_len);
-    ctx->iv_dec = pp_alloc_crypto(ctx->cipher_iv_len);
+    ctx->iv_enc = pp_alloc_crypto(ctx->crypto.meta.cipher_iv_len);
+    ctx->iv_dec = pp_alloc_crypto(ctx->crypto.meta.cipher_iv_len);
 
-    ctx->crypto.meta.cipher_key_len = ctx->cipher_key_len;
-    ctx->crypto.meta.cipher_iv_len = ctx->cipher_iv_len;
+    ctx->crypto.meta.cipher_key_len = EVP_CIPHER_key_length(ctx->cipher);
+    ctx->crypto.meta.cipher_iv_len = EVP_CIPHER_iv_length(ctx->cipher);
     ctx->crypto.meta.hmac_key_len = 0;
     ctx->crypto.meta.digest_len = 0;
     ctx->crypto.meta.tag_len = tag_len;
     ctx->crypto.meta.encryption_capacity = local_encryption_capacity;
+    ctx->id_len = id_len;
 
     ctx->crypto.encrypter.configure = local_configure_encrypt;
     ctx->crypto.encrypter.encrypt = local_encrypt;
@@ -183,6 +184,12 @@ crypto_ctx crypto_aead_create(const char *cipher_name, size_t tag_len, size_t id
     }
 
     return (crypto_ctx)ctx;
+
+failure:
+    if (ctx->ctx_enc) EVP_CIPHER_CTX_free(ctx->ctx_enc);
+    if (ctx->ctx_dec) EVP_CIPHER_CTX_free(ctx->ctx_dec);
+    free(ctx);
+    return NULL;
 }
 
 void crypto_aead_free(crypto_ctx vctx) {
@@ -191,9 +198,8 @@ void crypto_aead_free(crypto_ctx vctx) {
 
     EVP_CIPHER_CTX_free(ctx->ctx_enc);
     EVP_CIPHER_CTX_free(ctx->ctx_dec);
-
-    pp_zero(ctx->iv_enc, ctx->cipher_iv_len);
-    pp_zero(ctx->iv_dec, ctx->cipher_iv_len);
+    pp_zero(ctx->iv_enc, ctx->crypto.meta.cipher_iv_len);
+    pp_zero(ctx->iv_dec, ctx->crypto.meta.cipher_iv_len);
     free(ctx->iv_enc);
     free(ctx->iv_dec);
     free(ctx);

--- a/Sources/Crypto/OpenSSL_C/crypto_aead.c
+++ b/Sources/Crypto/OpenSSL_C/crypto_aead.c
@@ -162,15 +162,15 @@ crypto_ctx crypto_aead_create(const char *cipher_name,
 
     // no longer fails
 
-    ctx->iv_enc = pp_alloc_crypto(ctx->crypto.meta.cipher_iv_len);
-    ctx->iv_dec = pp_alloc_crypto(ctx->crypto.meta.cipher_iv_len);
-
     ctx->crypto.meta.cipher_key_len = EVP_CIPHER_key_length(ctx->cipher);
     ctx->crypto.meta.cipher_iv_len = EVP_CIPHER_iv_length(ctx->cipher);
     ctx->crypto.meta.hmac_key_len = 0;
     ctx->crypto.meta.digest_len = 0;
     ctx->crypto.meta.tag_len = tag_len;
     ctx->crypto.meta.encryption_capacity = local_encryption_capacity;
+
+    ctx->iv_enc = pp_alloc_crypto(ctx->crypto.meta.cipher_iv_len);
+    ctx->iv_dec = pp_alloc_crypto(ctx->crypto.meta.cipher_iv_len);
     ctx->id_len = id_len;
 
     ctx->crypto.encrypter.configure = local_configure_encrypt;

--- a/Sources/Crypto/OpenSSL_C/crypto_aead.c
+++ b/Sources/Crypto/OpenSSL_C/crypto_aead.c
@@ -23,7 +23,6 @@
 //  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
 #include <openssl/evp.h>
 #include <string.h>
 #include "crypto/allocation.h"

--- a/Sources/Crypto/OpenSSL_C/crypto_aead.c
+++ b/Sources/Crypto/OpenSSL_C/crypto_aead.c
@@ -48,14 +48,14 @@ typedef struct {
 static inline
 void local_prepare_iv(const void *vctx, uint8_t *_Nonnull iv, const zeroing_data_t *_Nonnull hmac_key) {
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
-    assert(ctx);
+    pp_assert(ctx);
     bzero(iv, ctx->id_len);
     memcpy(iv + ctx->id_len, hmac_key->bytes, ctx->cipher_iv_len - ctx->id_len);
 }
 
 size_t local_encryption_capacity(const void *vctx, size_t len) {
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
-    assert(ctx);
+    pp_assert(ctx);
     return pp_alloc_crypto_capacity(len, ctx->tag_len);
 }
 
@@ -63,9 +63,9 @@ static
 void local_configure_encrypt(void *vctx,
                              const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
-    assert(ctx);
-    assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
-    assert(hmac_key);
+    pp_assert(ctx);
+    pp_assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
+    pp_assert(hmac_key);
 
     EVP_CIPHER_CTX_reset(ctx->ctx_enc);
     EVP_CipherInit(ctx->ctx_enc, ctx->cipher, cipher_key->bytes, NULL, 1);
@@ -80,10 +80,10 @@ size_t local_encrypt(void *vctx,
                      const crypto_flags_t *flags,
                      crypto_error_code *error) {
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
-    assert(ctx);
-    assert(ctx->ctx_enc);
-    assert(flags);
-    assert(flags->ad_len >= ctx->id_len);
+    pp_assert(ctx);
+    pp_assert(ctx->ctx_enc);
+    pp_assert(flags);
+    pp_assert(flags->ad_len >= ctx->id_len);
 
     EVP_CIPHER_CTX *ossl = ctx->ctx_enc;
     int l1 = 0, l2 = 0, tmp = 0, code = 1;
@@ -105,9 +105,9 @@ static
 void local_configure_decrypt(void *vctx,
                              const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
-    assert(ctx);
-    assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
-    assert(hmac_key);
+    pp_assert(ctx);
+    pp_assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
+    pp_assert(hmac_key);
 
     EVP_CIPHER_CTX_reset(ctx->ctx_dec);
     EVP_CipherInit(ctx->ctx_dec, ctx->cipher, cipher_key->bytes, NULL, 0);
@@ -122,10 +122,10 @@ size_t local_decrypt(void *vctx,
                      const crypto_flags_t *flags,
                      crypto_error_code *error) {
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
-    assert(ctx);
-    assert(ctx->ctx_dec);
-    assert(flags);
-    assert(flags->ad_len >= ctx->id_len);
+    pp_assert(ctx);
+    pp_assert(ctx->ctx_dec);
+    pp_assert(flags);
+    pp_assert(flags->ad_len >= ctx->id_len);
 
     EVP_CIPHER_CTX *ossl = ctx->ctx_dec;
     int l1 = 0, l2 = 0, tmp = 0, code = 1;
@@ -147,7 +147,7 @@ size_t local_decrypt(void *vctx,
 
 crypto_ctx crypto_aead_create(const char *cipher_name, size_t tag_len, size_t id_len,
                               const crypto_keys_t *keys) {
-    assert(cipher_name);
+    pp_assert(cipher_name);
 
     const EVP_CIPHER *cipher = EVP_get_cipherbyname(cipher_name);
     if (!cipher) {

--- a/Sources/Crypto/OpenSSL_C/crypto_cbc.c
+++ b/Sources/Crypto/OpenSSL_C/crypto_cbc.c
@@ -23,7 +23,6 @@
 //  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <string.h>

--- a/Sources/Crypto/OpenSSL_C/crypto_cbc.c
+++ b/Sources/Crypto/OpenSSL_C/crypto_cbc.c
@@ -109,9 +109,9 @@ size_t local_encrypt(void *vctx,
     }
 
     EVP_MAC_CTX *mac_ctx = EVP_MAC_CTX_new(ctx->mac);
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_init(mac_ctx, ctx->hmac_key_enc->bytes, ctx->hmac_key_enc->length, ctx->mac_params))
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_update(mac_ctx, out_iv, ciphertext_len + final_len + ctx->crypto.meta.cipher_iv_len))
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_final(mac_ctx, out, &mac_len, ctx->crypto.meta.digest_len))
+    CRYPTO_CHECK_MAC(EVP_MAC_init(mac_ctx, ctx->hmac_key_enc->bytes, ctx->hmac_key_enc->length, ctx->mac_params))
+    CRYPTO_CHECK_MAC(EVP_MAC_update(mac_ctx, out_iv, ciphertext_len + final_len + ctx->crypto.meta.cipher_iv_len))
+    CRYPTO_CHECK_MAC(EVP_MAC_final(mac_ctx, out, &mac_len, ctx->crypto.meta.digest_len))
     EVP_MAC_CTX_free(mac_ctx);
 
     const size_t out_len = ciphertext_len + final_len + ctx->crypto.meta.cipher_iv_len + ctx->crypto.meta.digest_len;
@@ -151,9 +151,9 @@ size_t local_decrypt(void *vctx,
     size_t mac_len = 0;
 
     EVP_MAC_CTX *mac_ctx = EVP_MAC_CTX_new(ctx->mac);
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_init(mac_ctx, ctx->hmac_key_dec->bytes, ctx->hmac_key_dec->length, ctx->mac_params))
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_update(mac_ctx, in + ctx->crypto.meta.digest_len, in_len - ctx->crypto.meta.digest_len))
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_final(mac_ctx, ctx->buffer_hmac, &mac_len, ctx->crypto.meta.digest_len))
+    CRYPTO_CHECK_MAC(EVP_MAC_init(mac_ctx, ctx->hmac_key_dec->bytes, ctx->hmac_key_dec->length, ctx->mac_params))
+    CRYPTO_CHECK_MAC(EVP_MAC_update(mac_ctx, in + ctx->crypto.meta.digest_len, in_len - ctx->crypto.meta.digest_len))
+    CRYPTO_CHECK_MAC(EVP_MAC_final(mac_ctx, ctx->buffer_hmac, &mac_len, ctx->crypto.meta.digest_len))
     EVP_MAC_CTX_free(mac_ctx);
 
     pp_assert(mac_len == ctx->crypto.meta.digest_len);
@@ -184,9 +184,9 @@ bool local_verify(void *vctx, const uint8_t *in, size_t in_len, crypto_error_cod
 
     size_t mac_len = 0;
     EVP_MAC_CTX *mac_ctx = EVP_MAC_CTX_new(ctx->mac);
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_init(mac_ctx, ctx->hmac_key_dec->bytes, ctx->hmac_key_dec->length, ctx->mac_params))
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_update(mac_ctx, in + ctx->crypto.meta.digest_len, in_len - ctx->crypto.meta.digest_len))
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_final(mac_ctx, ctx->buffer_hmac, &mac_len, ctx->crypto.meta.digest_len))
+    CRYPTO_CHECK_MAC(EVP_MAC_init(mac_ctx, ctx->hmac_key_dec->bytes, ctx->hmac_key_dec->length, ctx->mac_params))
+    CRYPTO_CHECK_MAC(EVP_MAC_update(mac_ctx, in + ctx->crypto.meta.digest_len, in_len - ctx->crypto.meta.digest_len))
+    CRYPTO_CHECK_MAC(EVP_MAC_final(mac_ctx, ctx->buffer_hmac, &mac_len, ctx->crypto.meta.digest_len))
     EVP_MAC_CTX_free(mac_ctx);
 
     pp_assert(mac_len == ctx->crypto.meta.digest_len);

--- a/Sources/Crypto/OpenSSL_C/crypto_cbc.c
+++ b/Sources/Crypto/OpenSSL_C/crypto_cbc.c
@@ -67,10 +67,9 @@ void local_configure_encrypt(void *vctx, const zeroing_data_t *cipher_key, const
 
     if (ctx->cipher) {
         pp_assert(cipher_key && cipher_key->length >= ctx->crypto.meta.cipher_key_len);
-        EVP_CIPHER_CTX_reset(ctx->ctx_enc);
-        EVP_CipherInit(ctx->ctx_enc, ctx->cipher, cipher_key->bytes, NULL, 1);
+        CRYPTO_ASSERT(EVP_CIPHER_CTX_reset(ctx->ctx_enc))
+        CRYPTO_ASSERT(EVP_CipherInit(ctx->ctx_enc, ctx->cipher, cipher_key->bytes, NULL, 1))
     }
-
     if (ctx->hmac_key_enc) {
         zd_free(ctx->hmac_key_enc);
     }
@@ -127,10 +126,9 @@ void local_configure_decrypt(void *vctx, const zeroing_data_t *cipher_key, const
 
     if (ctx->cipher) {
         pp_assert(cipher_key && cipher_key->length >= ctx->crypto.meta.cipher_key_len);
-        EVP_CIPHER_CTX_reset(ctx->ctx_dec);
-        EVP_CipherInit(ctx->ctx_dec, ctx->cipher, cipher_key->bytes, NULL, 0);
+        CRYPTO_ASSERT(EVP_CIPHER_CTX_reset(ctx->ctx_dec))
+        CRYPTO_ASSERT(EVP_CipherInit(ctx->ctx_dec, ctx->cipher, cipher_key->bytes, NULL, 0))
     }
-
     if (ctx->hmac_key_dec) {
         zd_free(ctx->hmac_key_dec);
     }

--- a/Sources/Crypto/OpenSSL_C/crypto_cbc.c
+++ b/Sources/Crypto/OpenSSL_C/crypto_cbc.c
@@ -57,18 +57,18 @@ typedef struct {
 static
 size_t local_encryption_capacity(const void *vctx, size_t input_len) {
     const crypto_cbc_ctx *ctx = (crypto_cbc_ctx *)vctx;
-    assert(ctx);
+    pp_assert(ctx);
     return pp_alloc_crypto_capacity(input_len, ctx->digest_len + ctx->cipher_iv_len);
 }
 
 static
 void local_configure_encrypt(void *vctx, const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_cbc_ctx *ctx = (crypto_cbc_ctx *)vctx;
-    assert(ctx);
-    assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
+    pp_assert(ctx);
+    pp_assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
 
     if (ctx->cipher) {
-        assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
+        pp_assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
         EVP_CIPHER_CTX_reset(ctx->ctx_enc);
         EVP_CipherInit(ctx->ctx_enc, ctx->cipher, cipher_key->bytes, NULL, 1);
     }
@@ -85,9 +85,9 @@ size_t local_encrypt(void *vctx,
                      const uint8_t *in, size_t in_len,
                      const crypto_flags_t *flags, crypto_error_code *error) {
     crypto_cbc_ctx *ctx = (crypto_cbc_ctx *)vctx;
-    assert(ctx);
-    assert(!ctx->cipher || ctx->ctx_enc);
-    assert(ctx->hmac_key_enc);
+    pp_assert(ctx);
+    pp_assert(!ctx->cipher || ctx->ctx_enc);
+    pp_assert(ctx->hmac_key_enc);
 
     // output = [-digest-|-iv-|-payload-]
     uint8_t *out_iv = out + ctx->digest_len;
@@ -106,7 +106,7 @@ size_t local_encrypt(void *vctx,
         CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_CipherUpdate(ctx->ctx_enc, out_encrypted, &l1, in, (int)in_len);
         CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_CipherFinal_ex(ctx->ctx_enc, out_encrypted + l1, &l2);
     } else {
-        assert(out_encrypted == out_iv);
+        pp_assert(out_encrypted == out_iv);
         memcpy(out_encrypted, in, in_len);
         l1 = (int)in_len;
     }
@@ -125,11 +125,11 @@ size_t local_encrypt(void *vctx,
 static
 void local_configure_decrypt(void *vctx, const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_cbc_ctx *ctx = (crypto_cbc_ctx *)vctx;
-    assert(ctx);
-    assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
+    pp_assert(ctx);
+    pp_assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
 
     if (ctx->cipher) {
-        assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
+        pp_assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
         EVP_CIPHER_CTX_reset(ctx->ctx_dec);
         EVP_CipherInit(ctx->ctx_dec, ctx->cipher, cipher_key->bytes, NULL, 0);
     }
@@ -147,9 +147,9 @@ size_t local_decrypt(void *vctx,
                      const crypto_flags_t *flags, crypto_error_code *error) {
     (void)flags;
     crypto_cbc_ctx *ctx = (crypto_cbc_ctx *)vctx;
-    assert(ctx);
-    assert(!ctx->cipher || ctx->ctx_dec);
-    assert(ctx->hmac_key_dec);
+    pp_assert(ctx);
+    pp_assert(!ctx->cipher || ctx->ctx_dec);
+    pp_assert(ctx->hmac_key_dec);
 
     const uint8_t *iv = in + ctx->digest_len;
     const uint8_t *encrypted = in + ctx->digest_len + ctx->cipher_iv_len;
@@ -183,7 +183,7 @@ size_t local_decrypt(void *vctx,
 static
 bool local_verify(void *vctx, const uint8_t *in, size_t in_len, crypto_error_code *error) {
     crypto_cbc_ctx *ctx = (crypto_cbc_ctx *)vctx;
-    assert(ctx);
+    pp_assert(ctx);
 
     size_t l1 = 0;
     int code = 1;
@@ -205,7 +205,7 @@ bool local_verify(void *vctx, const uint8_t *in, size_t in_len, crypto_error_cod
 
 crypto_ctx crypto_cbc_create(const char *cipher_name, const char *digest_name,
                              const crypto_keys_t *keys) {
-    assert(digest_name);
+    pp_assert(digest_name);
 
     const EVP_CIPHER *cipher = NULL;
     if (cipher_name) {

--- a/Sources/Crypto/OpenSSL_C/crypto_ctr.c
+++ b/Sources/Crypto/OpenSSL_C/crypto_ctr.c
@@ -89,10 +89,10 @@ size_t local_encrypt(void *vctx,
     size_t mac_len = 0;
 
     EVP_MAC_CTX *mac_ctx = EVP_MAC_CTX_new(ctx->mac);
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_init(mac_ctx, ctx->hmac_key_enc->bytes, ctx->hmac_key_enc->length, ctx->mac_params))
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_update(mac_ctx, flags->ad, flags->ad_len))
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_update(mac_ctx, in, in_len))
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_final(mac_ctx, out, &mac_len, ctx->ns_tag_len))
+    CRYPTO_CHECK_MAC(EVP_MAC_init(mac_ctx, ctx->hmac_key_enc->bytes, ctx->hmac_key_enc->length, ctx->mac_params))
+    CRYPTO_CHECK_MAC(EVP_MAC_update(mac_ctx, flags->ad, flags->ad_len))
+    CRYPTO_CHECK_MAC(EVP_MAC_update(mac_ctx, in, in_len))
+    CRYPTO_CHECK_MAC(EVP_MAC_final(mac_ctx, out, &mac_len, ctx->ns_tag_len))
     EVP_MAC_CTX_free(mac_ctx);
 
     pp_assert(mac_len == ctx->ns_tag_len);
@@ -145,10 +145,10 @@ size_t local_decrypt(void *vctx,
     const size_t out_len = plaintext_len + final_len;
 
     EVP_MAC_CTX *mac_ctx = EVP_MAC_CTX_new(ctx->mac);
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_init(mac_ctx, ctx->hmac_key_dec->bytes, ctx->hmac_key_dec->length, ctx->mac_params))
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_update(mac_ctx, flags->ad, flags->ad_len))
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_update(mac_ctx, out, out_len))
-    CRYPTO_CHECK_MAC(mac_ctx, EVP_MAC_final(mac_ctx, ctx->buffer_hmac, &mac_len, ctx->ns_tag_len))
+    CRYPTO_CHECK_MAC(EVP_MAC_init(mac_ctx, ctx->hmac_key_dec->bytes, ctx->hmac_key_dec->length, ctx->mac_params))
+    CRYPTO_CHECK_MAC(EVP_MAC_update(mac_ctx, flags->ad, flags->ad_len))
+    CRYPTO_CHECK_MAC(EVP_MAC_update(mac_ctx, out, out_len))
+    CRYPTO_CHECK_MAC(EVP_MAC_final(mac_ctx, ctx->buffer_hmac, &mac_len, ctx->ns_tag_len))
     EVP_MAC_CTX_free(mac_ctx);
 
     pp_assert(mac_len == ctx->ns_tag_len);

--- a/Sources/Crypto/OpenSSL_C/crypto_ctr.c
+++ b/Sources/Crypto/OpenSSL_C/crypto_ctr.c
@@ -56,7 +56,7 @@ typedef struct {
 static
 size_t local_encryption_capacity(const void *vctx, size_t len) {
     const crypto_ctr_ctx *ctx = (crypto_ctr_ctx *)vctx;
-    assert(ctx);
+    pp_assert(ctx);
     return pp_alloc_crypto_capacity(len, ctx->payload_len + ctx->ns_tag_len);
 }
 
@@ -64,9 +64,9 @@ static
 void local_configure_encrypt(void *vctx,
                              const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_ctr_ctx *ctx = (crypto_ctr_ctx *)vctx;
-    assert(ctx);
-    assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
-    assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
+    pp_assert(ctx);
+    pp_assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
+    pp_assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
 
     EVP_CIPHER_CTX_reset(ctx->ctx_enc);
     EVP_CipherInit(ctx->ctx_enc, ctx->cipher, cipher_key->bytes, NULL, 1);
@@ -83,10 +83,10 @@ size_t local_encrypt(void *vctx,
                      const uint8_t *in, size_t in_len,
                      const crypto_flags_t *flags, crypto_error_code *error) {
     crypto_ctr_ctx *ctx = (crypto_ctr_ctx *)vctx;
-    assert(ctx);
-    assert(ctx->ctx_enc);
-    assert(ctx->hmac_key_enc);
-    assert(flags);
+    pp_assert(ctx);
+    pp_assert(ctx->ctx_enc);
+    pp_assert(ctx->hmac_key_enc);
+    pp_assert(flags);
 
     uint8_t *out_encrypted = out + ctx->ns_tag_len;
     int l1 = 0, l2 = 0;
@@ -100,7 +100,7 @@ size_t local_encrypt(void *vctx,
     CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_MAC_final(ossl, out, &l3, ctx->ns_tag_len);
     EVP_MAC_CTX_free(ossl);
 
-    assert(l3 == ctx->ns_tag_len);
+    pp_assert(l3 == ctx->ns_tag_len);
 
     CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_CipherInit(ctx->ctx_enc, NULL, NULL, out, -1);
     CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_CipherUpdate(ctx->ctx_enc, out_encrypted, &l1, in, (int)in_len);
@@ -114,9 +114,9 @@ size_t local_encrypt(void *vctx,
 static
 void local_configure_decrypt(void *vctx, const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_ctr_ctx *ctx = (crypto_ctr_ctx *)vctx;
-    assert(ctx);
-    assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
-    assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
+    pp_assert(ctx);
+    pp_assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
+    pp_assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
 
     EVP_CIPHER_CTX_reset(ctx->ctx_dec);
     EVP_CipherInit(ctx->ctx_dec, ctx->cipher, cipher_key->bytes, NULL, 0);
@@ -133,10 +133,10 @@ size_t local_decrypt(void *vctx,
                      const uint8_t *in, size_t in_len,
                      const crypto_flags_t *flags, crypto_error_code *error) {
     crypto_ctr_ctx *ctx = (crypto_ctr_ctx *)vctx;
-    assert(ctx);
-    assert(ctx->ctx_dec);
-    assert(ctx->hmac_key_dec);
-    assert(flags);
+    pp_assert(ctx);
+    pp_assert(ctx->ctx_dec);
+    pp_assert(ctx->hmac_key_dec);
+    pp_assert(flags);
 
     const uint8_t *iv = in;
     const uint8_t *encrypted = in + ctx->ns_tag_len;
@@ -157,7 +157,7 @@ size_t local_decrypt(void *vctx,
     CRYPTO_OPENSSL_TRACK_STATUS(code) EVP_MAC_final(ossl, ctx->buffer_hmac, &l3, ctx->ns_tag_len);
     EVP_MAC_CTX_free(ossl);
 
-    assert(l3 == ctx->ns_tag_len);
+    pp_assert(l3 == ctx->ns_tag_len);
 
     if (CRYPTO_OPENSSL_SUCCESS(code) && CRYPTO_memcmp(ctx->buffer_hmac, in, ctx->ns_tag_len) != 0) {
         CRYPTO_OPENSSL_RETURN_STATUS(code, CryptoErrorHMAC)
@@ -171,7 +171,7 @@ size_t local_decrypt(void *vctx,
 crypto_ctx crypto_ctr_create(const char *cipher_name, const char *digest_name,
                              size_t tag_len, size_t payload_len,
                              const crypto_keys_t *keys) {
-    assert(cipher_name && digest_name);
+    pp_assert(cipher_name && digest_name);
 
     const EVP_CIPHER *cipher = EVP_get_cipherbyname(cipher_name);
     if (!cipher) {

--- a/Sources/Crypto/OpenSSL_C/crypto_ctr.c
+++ b/Sources/Crypto/OpenSSL_C/crypto_ctr.c
@@ -66,9 +66,8 @@ void local_configure_encrypt(void *vctx,
     pp_assert(hmac_key && hmac_key->length >= ctx->crypto.meta.hmac_key_len);
     pp_assert(cipher_key && cipher_key->length >= ctx->crypto.meta.cipher_key_len);
 
-    EVP_CIPHER_CTX_reset(ctx->ctx_enc);
-    EVP_CipherInit(ctx->ctx_enc, ctx->cipher, cipher_key->bytes, NULL, 1);
-
+    CRYPTO_ASSERT(EVP_CIPHER_CTX_reset(ctx->ctx_enc))
+    CRYPTO_ASSERT(EVP_CipherInit(ctx->ctx_enc, ctx->cipher, cipher_key->bytes, NULL, 1))
     if (ctx->hmac_key_enc) {
         zd_free(ctx->hmac_key_enc);
     }
@@ -115,9 +114,8 @@ void local_configure_decrypt(void *vctx, const zeroing_data_t *cipher_key, const
     pp_assert(hmac_key && hmac_key->length >= ctx->crypto.meta.hmac_key_len);
     pp_assert(cipher_key && cipher_key->length >= ctx->crypto.meta.cipher_key_len);
 
-    EVP_CIPHER_CTX_reset(ctx->ctx_dec);
-    EVP_CipherInit(ctx->ctx_dec, ctx->cipher, cipher_key->bytes, NULL, 0);
-
+    CRYPTO_ASSERT(EVP_CIPHER_CTX_reset(ctx->ctx_dec))
+    CRYPTO_ASSERT(EVP_CipherInit(ctx->ctx_dec, ctx->cipher, cipher_key->bytes, NULL, 0))
     if (ctx->hmac_key_dec) {
         zd_free(ctx->hmac_key_dec);
     }

--- a/Sources/Crypto/OpenSSL_C/crypto_ctr.c
+++ b/Sources/Crypto/OpenSSL_C/crypto_ctr.c
@@ -23,7 +23,6 @@
 //  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
 #include <openssl/evp.h>
 #include <string.h>
 #include "crypto/allocation.h"

--- a/Sources/Crypto/OpenSSL_C/include/macros.h
+++ b/Sources/Crypto/OpenSSL_C/include/macros.h
@@ -35,12 +35,12 @@ if (code <= 0) {\
     return 0;\
 }
 
-#define CRYPTO_CHECK_MAC(mac, code)\
+#define CRYPTO_CHECK_MAC(code)\
 if (code <= 0) {\
     if (error) {\
         *error = CryptoErrorHMAC;\
     }\
-    EVP_MAC_CTX_free(mac);\
+    EVP_MAC_CTX_free(mac_ctx);\
     return 0;\
 }
 

--- a/Sources/Crypto/OpenSSL_C/include/macros.h
+++ b/Sources/Crypto/OpenSSL_C/include/macros.h
@@ -25,24 +25,24 @@
 
 #pragma once
 
-#define CRYPTO_OPENSSL_SUCCESS(code) (code > 0)
+#define CRYPTO_SET_ERROR(code)\
+if (error) {\
+    *error = code;\
+}
 
-#define CRYPTO_OPENSSL_TRACK_STATUS(code) if (code > 0) code =
-
-#define CRYPTO_OPENSSL_RETURN_STATUS(code, raised)\
+#define CRYPTO_CHECK(code)\
 if (code <= 0) {\
     if (error) {\
-        *error = raised;\
-    }\
-    return false;\
-}\
-return true;
-
-#define CRYPTO_OPENSSL_RETURN_LENGTH(code, length, raised)\
-if (code <= 0 || length == 0) {\
-    if (error) {\
-        *error = raised;\
+        *error = CryptoErrorEncryption;\
     }\
     return 0;\
-}\
-return length;
+}
+
+#define CRYPTO_CHECK_MAC(mac, code)\
+if (code <= 0) {\
+    if (error) {\
+        *error = CryptoErrorHMAC;\
+    }\
+    EVP_MAC_CTX_free(mac);\
+    return 0;\
+}

--- a/Sources/Crypto/OpenSSL_C/include/macros.h
+++ b/Sources/Crypto/OpenSSL_C/include/macros.h
@@ -25,10 +25,7 @@
 
 #pragma once
 
-#define CRYPTO_SET_ERROR(code)\
-if (error) {\
-    *error = code;\
-}
+#define CRYPTO_ASSERT(code) pp_assert(code > 0);
 
 #define CRYPTO_CHECK(code)\
 if (code <= 0) {\
@@ -45,4 +42,9 @@ if (code <= 0) {\
     }\
     EVP_MAC_CTX_free(mac);\
     return 0;\
+}
+
+#define CRYPTO_SET_ERROR(code)\
+if (error) {\
+    *error = code;\
 }

--- a/Sources/Crypto/OpenSSL_C/include/macros.h
+++ b/Sources/Crypto/OpenSSL_C/include/macros.h
@@ -25,26 +25,20 @@
 
 #pragma once
 
-#define CRYPTO_ASSERT(code) pp_assert(code > 0);
+#define CRYPTO_ASSERT(ossl_code) pp_assert(ossl_code > 0);
 
-#define CRYPTO_CHECK(code)\
-if (code <= 0) {\
-    if (error) {\
-        *error = CryptoErrorEncryption;\
-    }\
+#define CRYPTO_CHECK(ossl_code)\
+if (ossl_code <= 0) {\
+    if (error) *error = CryptoErrorEncryption;\
     return 0;\
 }
 
-#define CRYPTO_CHECK_MAC(code)\
-if (code <= 0) {\
-    if (error) {\
-        *error = CryptoErrorHMAC;\
-    }\
+#define CRYPTO_CHECK_MAC(ossl_code)\
+if (ossl_code <= 0) {\
+    if (error) *error = CryptoErrorHMAC;\
     EVP_MAC_CTX_free(mac_ctx);\
     return 0;\
 }
 
-#define CRYPTO_SET_ERROR(code)\
-if (error) {\
-    *error = code;\
-}
+#define CRYPTO_SET_ERROR(crypto_code)\
+if (error) *error = crypto_code;\

--- a/Sources/Crypto/OpenSSL_C/keys.c
+++ b/Sources/Crypto/OpenSSL_C/keys.c
@@ -23,7 +23,6 @@
 //  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/pem.h>

--- a/Sources/Crypto/OpenSSL_C/keys.c
+++ b/Sources/Crypto/OpenSSL_C/keys.c
@@ -47,7 +47,7 @@ zeroing_data_t *key_hmac_create() {
 }
 
 size_t key_hmac_do(key_hmac_ctx *ctx) {
-    assert(ctx->dst->length >= KeyHMACMaxLength);
+    pp_assert(ctx->dst->length >= KeyHMACMaxLength);
 
     const EVP_MD *md = EVP_get_digestbyname(ctx->digest_name);
     if (!md) {

--- a/Sources/Crypto/OpenSSL_C/tls.c
+++ b/Sources/Crypto/OpenSSL_C/tls.c
@@ -23,7 +23,6 @@
 //  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
 #include <openssl/bio.h>
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>

--- a/Sources/Crypto/OpenSSL_C/tls.c
+++ b/Sources/Crypto/OpenSSL_C/tls.c
@@ -240,7 +240,7 @@ zeroing_data_t *_Nullable tls_channel_pull_cipher(tls_channel_ctx _Nonnull tls,
             return NULL;
         }
         if (tls->opt->san_host) {
-            assert(tls->opt->hostname);
+            pp_assert(tls->opt->hostname);
             if (!tls_channel_verify_ssl_san_host(tls->ssl, tls->opt->hostname)) {
                 if (error) {
                     *error = TLSErrorServerHost;
@@ -330,7 +330,7 @@ char *tls_channel_ca_md5(const tls_channel_ctx tls) {
     X509_digest(cert, alg, md, &len);
     X509_free(cert);
     fclose(pem);
-    assert(len == sizeof(md));//, @"Unexpected MD5 size (%d != %lu)", len, sizeof(md));
+    pp_assert(len == sizeof(md));//, @"Unexpected MD5 size (%d != %lu)", len, sizeof(md));
 
     char *hex = pp_alloc_crypto(2 * sizeof(md) + 1);
     char *ptr = hex;

--- a/Sources/Crypto/Windows_C/crypto_aead.c
+++ b/Sources/Crypto/Windows_C/crypto_aead.c
@@ -32,26 +32,23 @@
 
 #pragma comment(lib, "bcrypt.lib")
 
-// Internal context for AEAD using Windows CNG
 typedef struct {
     crypto_t crypto;
 
+    // cipher
     BCRYPT_ALG_HANDLE hAlg;
     BCRYPT_KEY_HANDLE hKeyEnc;
     BCRYPT_KEY_HANDLE hKeyDec;
-    size_t cipher_key_len;
-    size_t cipher_iv_len;
-    size_t tag_len;
-    size_t id_len;
-
     uint8_t *_Nonnull iv_enc;
     uint8_t *_Nonnull iv_dec;
+    size_t id_len;
+    UCHAR tag[128]; // max length
 } crypto_aead_ctx;
 
 size_t local_encryption_capacity(const void *vctx, size_t len) {
     const crypto_aead_ctx *ctx = (const crypto_aead_ctx *)vctx;
     pp_assert(ctx);
-    return pp_alloc_crypto_capacity(len, ctx->tag_len);
+    return pp_alloc_crypto_capacity(len, ctx->crypto.meta.tag_len);
 }
 
 static
@@ -59,24 +56,23 @@ void local_configure_encrypt(void *vctx,
                              const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
     pp_assert(ctx);
-    pp_assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
+    pp_assert(cipher_key && cipher_key->length >= ctx->crypto.meta.cipher_key_len);
     pp_assert(hmac_key);
 
     if (ctx->hKeyEnc) {
         BCryptDestroyKey(ctx->hKeyEnc);
         ctx->hKeyEnc = NULL;
     }
-    NTSTATUS status = BCryptGenerateSymmetricKey(
+    CRYPTO_ASSERT(BCryptGenerateSymmetricKey(
         ctx->hAlg,
         &ctx->hKeyEnc,
         NULL, 0,
         (PUCHAR)cipher_key->bytes,
-        (ULONG)ctx->cipher_key_len,
+        (ULONG)ctx->crypto.meta.cipher_key_len,
         0
-    );
-    pp_assert(CRYPTO_CNG_SUCCESS(status));
+    ))
     memset(ctx->iv_enc, 0, ctx->id_len);
-    memcpy(ctx->iv_enc + ctx->id_len, hmac_key->bytes, ctx->cipher_iv_len - ctx->id_len);
+    memcpy(ctx->iv_enc + ctx->id_len, hmac_key->bytes, ctx->crypto.meta.cipher_iv_len - ctx->id_len);
 }
 
 static
@@ -90,32 +86,31 @@ size_t local_encrypt(void *vctx,
     pp_assert(flags);
     pp_assert(flags->ad_len >= ctx->id_len);
 
-    NTSTATUS status;
     ULONG cbResult = 0;
-    UCHAR tag[16] = {0};
     BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO authInfo;
+
     BCRYPT_INIT_AUTH_MODE_INFO(authInfo);
-    memcpy(ctx->iv_enc, flags->iv, (size_t)MIN(flags->iv_len, ctx->cipher_iv_len));
+    memcpy(ctx->iv_enc, flags->iv, (size_t)MIN(flags->iv_len, ctx->crypto.meta.cipher_iv_len));
     authInfo.pbNonce = ctx->iv_enc;
-    authInfo.cbNonce = (ULONG)ctx->cipher_iv_len;
+    authInfo.cbNonce = (ULONG)ctx->crypto.meta.cipher_iv_len;
     authInfo.pbAuthData = (PUCHAR)flags->ad;
     authInfo.cbAuthData = (ULONG)flags->ad_len;
-    authInfo.pbTag = tag;
-    authInfo.cbTag = (ULONG)ctx->tag_len;
+    authInfo.pbTag = ctx->tag;
+    authInfo.cbTag = (ULONG)ctx->crypto.meta.tag_len;
 
-    CRYPTO_CNG_TRACK_STATUS(status) BCryptEncrypt(
+    CRYPTO_CHECK(BCryptEncrypt(
         ctx->hKeyEnc,
         (PUCHAR)in, (ULONG)in_len,
         &authInfo,
         NULL, 0,
-        out + ctx->tag_len, (ULONG)(out_buf_len - ctx->tag_len),
+        out + ctx->crypto.meta.tag_len,
+        (ULONG)(out_buf_len - ctx->crypto.meta.tag_len),
         &cbResult,
         0
-    );
-    CRYPTO_CNG_RETURN_IF_FAILED(status, CryptoErrorEncryption)
+    ))
+    memcpy(out, ctx->tag, ctx->crypto.meta.tag_len);
 
-    memcpy(out, tag, ctx->tag_len);
-    const size_t out_len = ctx->tag_len + cbResult;
+    const size_t out_len = ctx->crypto.meta.tag_len + cbResult;
     return out_len;
 }
 
@@ -124,24 +119,23 @@ void local_configure_decrypt(void *vctx,
                              const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
     pp_assert(ctx);
-    pp_assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
+    pp_assert(cipher_key && cipher_key->length >= ctx->crypto.meta.cipher_key_len);
     pp_assert(hmac_key);
 
     if (ctx->hKeyDec) {
         BCryptDestroyKey(ctx->hKeyDec);
         ctx->hKeyDec = NULL;
     }
-    NTSTATUS status = BCryptGenerateSymmetricKey(
+    CRYPTO_ASSERT(BCryptGenerateSymmetricKey(
         ctx->hAlg,
         &ctx->hKeyDec,
         NULL, 0,
         (PUCHAR)cipher_key->bytes,
-        (ULONG)ctx->cipher_key_len,
+        (ULONG)ctx->crypto.meta.cipher_key_len,
         0
-    );
-    pp_assert(CRYPTO_CNG_SUCCESS(status));
+    ))
     memset(ctx->iv_dec, 0, ctx->id_len);
-    memcpy(ctx->iv_dec + ctx->id_len, hmac_key->bytes, ctx->cipher_iv_len - ctx->id_len);
+    memcpy(ctx->iv_dec + ctx->id_len, hmac_key->bytes, ctx->crypto.meta.cipher_iv_len - ctx->id_len);
 }
 
 static
@@ -155,28 +149,28 @@ size_t local_decrypt(void *vctx,
     pp_assert(flags);
     pp_assert(flags->ad_len >= ctx->id_len);
 
-    NTSTATUS status;
     ULONG cbResult = 0;
     BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO authInfo;
+
     BCRYPT_INIT_AUTH_MODE_INFO(authInfo);
-    memcpy(ctx->iv_dec, flags->iv, (size_t)MIN(flags->iv_len, ctx->cipher_iv_len));
+    memcpy(ctx->iv_dec, flags->iv, (size_t)MIN(flags->iv_len, ctx->crypto.meta.cipher_iv_len));
     authInfo.pbNonce = ctx->iv_dec;
-    authInfo.cbNonce = (ULONG)ctx->cipher_iv_len;
+    authInfo.cbNonce = (ULONG)ctx->crypto.meta.cipher_iv_len;
     authInfo.pbAuthData = (PUCHAR)flags->ad;
     authInfo.cbAuthData = (ULONG)flags->ad_len;
     authInfo.pbTag = (PUCHAR)in;
-    authInfo.cbTag = (ULONG)ctx->tag_len;
+    authInfo.cbTag = (ULONG)ctx->crypto.meta.tag_len;
 
-    CRYPTO_CNG_TRACK_STATUS(status) BCryptDecrypt(
+    CRYPTO_CHECK(BCryptDecrypt(
         ctx->hKeyDec,
-        (PUCHAR)(in + ctx->tag_len), (ULONG)(in_len - ctx->tag_len),
+        (PUCHAR)(in + ctx->crypto.meta.tag_len),
+        (ULONG)(in_len - ctx->crypto.meta.tag_len),
         &authInfo,
         NULL, 0,
         out, out_buf_len,
         &cbResult,
         0
-    );
-    CRYPTO_CNG_RETURN_IF_FAILED(status, CryptoErrorEncryption)
+    ))
 
     const size_t out_len = cbResult;
     return out_len;
@@ -184,7 +178,8 @@ size_t local_decrypt(void *vctx,
 
 // MARK: -
 
-crypto_ctx crypto_aead_create(const char *cipher_name, size_t tag_len, size_t id_len,
+crypto_ctx crypto_aead_create(const char *cipher_name,
+                              size_t tag_len, size_t id_len,
                               const crypto_keys_t *keys) {
     pp_assert(cipher_name);
 
@@ -198,38 +193,32 @@ crypto_ctx crypto_aead_create(const char *cipher_name, size_t tag_len, size_t id
     }
 
     crypto_aead_ctx *ctx = pp_alloc_crypto(sizeof(crypto_aead_ctx));
-    ctx->tag_len = tag_len;
-    ctx->id_len = id_len;
-    ctx->cipher_key_len = cipher_key_len;
-    ctx->cipher_iv_len = 12;  // Standard GCM IV size
-    ctx->hAlg = NULL;
-    ctx->hKeyEnc = NULL;
-    ctx->hKeyDec = NULL;
-    ctx->iv_enc = pp_alloc_crypto(ctx->cipher_iv_len);
-    ctx->iv_dec = pp_alloc_crypto(ctx->cipher_iv_len);
-
-    NTSTATUS status;
-    CRYPTO_CNG_TRACK_STATUS(status) BCryptOpenAlgorithmProvider(
+    CRYPTO_CHECK_CREATE(BCryptOpenAlgorithmProvider(
         &ctx->hAlg,
         BCRYPT_AES_ALGORITHM,
         NULL,
         0
-    );
-    CRYPTO_CNG_TRACK_STATUS(status) BCryptSetProperty(
+    ));
+    CRYPTO_CHECK_CREATE(BCryptSetProperty(
         ctx->hAlg,
         BCRYPT_CHAINING_MODE,
         (PUCHAR)BCRYPT_CHAIN_MODE_GCM,
         (ULONG)sizeof(BCRYPT_CHAIN_MODE_GCM),
         0
-    );
-    CRYPTO_CNG_CLOSE_IF_FAILED(status, ctx->hAlg)
+    ));
 
-    ctx->crypto.meta.cipher_key_len = ctx->cipher_key_len;
-    ctx->crypto.meta.cipher_iv_len = ctx->cipher_iv_len;
+    // no longer fails
+
+    ctx->iv_enc = pp_alloc_crypto(ctx->crypto.meta.cipher_iv_len);
+    ctx->iv_dec = pp_alloc_crypto(ctx->crypto.meta.cipher_iv_len);
+
+    ctx->crypto.meta.cipher_key_len = cipher_key_len;
+    ctx->crypto.meta.cipher_iv_len = 12; // standard GCM IV size
     ctx->crypto.meta.hmac_key_len = 0;
     ctx->crypto.meta.digest_len = 0;
     ctx->crypto.meta.tag_len = tag_len;
     ctx->crypto.meta.encryption_capacity = local_encryption_capacity;
+    ctx->id_len = id_len;
 
     ctx->crypto.encrypter.configure = local_configure_encrypt;
     ctx->crypto.encrypter.encrypt = local_encrypt;
@@ -241,18 +230,26 @@ crypto_ctx crypto_aead_create(const char *cipher_name, size_t tag_len, size_t id
         local_configure_encrypt(ctx, keys->cipher.enc_key, keys->hmac.enc_key);
         local_configure_decrypt(ctx, keys->cipher.dec_key, keys->hmac.dec_key);
     }
+
     return (crypto_ctx)ctx;
+
+failure:
+    if (ctx->hAlg) BCryptCloseAlgorithmProvider(ctx->hAlg, 0);
+    free(ctx);
+    return NULL;
 }
 
 void crypto_aead_free(crypto_ctx vctx) {
     if (!vctx) return;
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
+
     if (ctx->hKeyEnc) BCryptDestroyKey(ctx->hKeyEnc);
     if (ctx->hKeyDec) BCryptDestroyKey(ctx->hKeyDec);
-    if (ctx->hAlg) BCryptCloseAlgorithmProvider(ctx->hAlg, 0);
-    pp_zero(ctx->iv_enc, ctx->cipher_iv_len);
-    pp_zero(ctx->iv_dec, ctx->cipher_iv_len);
+    BCryptCloseAlgorithmProvider(ctx->hAlg, 0);
+    pp_zero(ctx->iv_enc, ctx->crypto.meta.cipher_iv_len);
+    pp_zero(ctx->iv_dec, ctx->crypto.meta.cipher_iv_len);
     free(ctx->iv_enc);
     free(ctx->iv_dec);
+
     free(ctx);
 } 

--- a/Sources/Crypto/Windows_C/crypto_aead.c
+++ b/Sources/Crypto/Windows_C/crypto_aead.c
@@ -209,15 +209,15 @@ crypto_ctx crypto_aead_create(const char *cipher_name,
 
     // no longer fails
 
-    ctx->iv_enc = pp_alloc_crypto(ctx->crypto.meta.cipher_iv_len);
-    ctx->iv_dec = pp_alloc_crypto(ctx->crypto.meta.cipher_iv_len);
-
     ctx->crypto.meta.cipher_key_len = cipher_key_len;
     ctx->crypto.meta.cipher_iv_len = 12; // standard GCM IV size
     ctx->crypto.meta.hmac_key_len = 0;
     ctx->crypto.meta.digest_len = 0;
     ctx->crypto.meta.tag_len = tag_len;
     ctx->crypto.meta.encryption_capacity = local_encryption_capacity;
+
+    ctx->iv_enc = pp_alloc_crypto(ctx->crypto.meta.cipher_iv_len);
+    ctx->iv_dec = pp_alloc_crypto(ctx->crypto.meta.cipher_iv_len);
     ctx->id_len = id_len;
 
     ctx->crypto.encrypter.configure = local_configure_encrypt;

--- a/Sources/Crypto/Windows_C/crypto_aead.c
+++ b/Sources/Crypto/Windows_C/crypto_aead.c
@@ -23,7 +23,6 @@
 //  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
 #include <windows.h>
 #include <bcrypt.h>
 #include <string.h>

--- a/Sources/Crypto/Windows_C/crypto_aead.c
+++ b/Sources/Crypto/Windows_C/crypto_aead.c
@@ -51,7 +51,7 @@ typedef struct {
 
 size_t local_encryption_capacity(const void *vctx, size_t len) {
     const crypto_aead_ctx *ctx = (const crypto_aead_ctx *)vctx;
-    assert(ctx);
+    pp_assert(ctx);
     return pp_alloc_crypto_capacity(len, ctx->tag_len);
 }
 
@@ -59,9 +59,9 @@ static
 void local_configure_encrypt(void *vctx,
                              const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
-    assert(ctx);
-    assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
-    assert(hmac_key);
+    pp_assert(ctx);
+    pp_assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
+    pp_assert(hmac_key);
 
     if (ctx->hKeyEnc) {
         BCryptDestroyKey(ctx->hKeyEnc);
@@ -75,7 +75,7 @@ void local_configure_encrypt(void *vctx,
         (ULONG)ctx->cipher_key_len,
         0
     );
-    assert(CRYPTO_CNG_SUCCESS(status));
+    pp_assert(CRYPTO_CNG_SUCCESS(status));
     memset(ctx->iv_enc, 0, ctx->id_len);
     memcpy(ctx->iv_enc + ctx->id_len, hmac_key->bytes, ctx->cipher_iv_len - ctx->id_len);
 }
@@ -86,10 +86,10 @@ size_t local_encrypt(void *vctx,
                      const uint8_t *in, size_t in_len,
                      const crypto_flags_t *flags, crypto_error_code *error) {
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
-    assert(ctx);
-    assert(ctx->hKeyEnc);
-    assert(flags);
-    assert(flags->ad_len >= ctx->id_len);
+    pp_assert(ctx);
+    pp_assert(ctx->hKeyEnc);
+    pp_assert(flags);
+    pp_assert(flags->ad_len >= ctx->id_len);
 
     NTSTATUS status;
     ULONG cbResult = 0;
@@ -124,9 +124,9 @@ static
 void local_configure_decrypt(void *vctx,
                              const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
-    assert(ctx);
-    assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
-    assert(hmac_key);
+    pp_assert(ctx);
+    pp_assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
+    pp_assert(hmac_key);
 
     if (ctx->hKeyDec) {
         BCryptDestroyKey(ctx->hKeyDec);
@@ -140,7 +140,7 @@ void local_configure_decrypt(void *vctx,
         (ULONG)ctx->cipher_key_len,
         0
     );
-    assert(CRYPTO_CNG_SUCCESS(status));
+    pp_assert(CRYPTO_CNG_SUCCESS(status));
     memset(ctx->iv_dec, 0, ctx->id_len);
     memcpy(ctx->iv_dec + ctx->id_len, hmac_key->bytes, ctx->cipher_iv_len - ctx->id_len);
 }
@@ -151,10 +151,10 @@ size_t local_decrypt(void *vctx,
                      const uint8_t *in, size_t in_len,
                      const crypto_flags_t *flags, crypto_error_code *error) {
     crypto_aead_ctx *ctx = (crypto_aead_ctx *)vctx;
-    assert(ctx);
-    assert(ctx->hKeyDec);
-    assert(flags);
-    assert(flags->ad_len >= ctx->id_len);
+    pp_assert(ctx);
+    pp_assert(ctx->hKeyDec);
+    pp_assert(flags);
+    pp_assert(flags->ad_len >= ctx->id_len);
 
     NTSTATUS status;
     ULONG cbResult = 0;
@@ -187,7 +187,7 @@ size_t local_decrypt(void *vctx,
 
 crypto_ctx crypto_aead_create(const char *cipher_name, size_t tag_len, size_t id_len,
                               const crypto_keys_t *keys) {
-    assert(cipher_name);
+    pp_assert(cipher_name);
 
     size_t cipher_key_len;
     if (!_stricmp(cipher_name, "AES-128-GCM")) {

--- a/Sources/Crypto/Windows_C/crypto_cbc.c
+++ b/Sources/Crypto/Windows_C/crypto_cbc.c
@@ -38,19 +38,13 @@
 typedef struct {
     crypto_t crypto;
 
+    // cipher
     BCRYPT_ALG_HANDLE hAlgCipher;
-    BCRYPT_ALG_HANDLE hAlgHmac;
     BCRYPT_KEY_HANDLE hKeyEnc;
     BCRYPT_KEY_HANDLE hKeyDec;
-    BCRYPT_HASH_HANDLE hHmacEnc;
-    BCRYPT_HASH_HANDLE hHmacDec;
-    size_t cipher_key_len;
-    size_t cipher_iv_len;
-    size_t hmac_key_len;
-    size_t digest_len;
 
-    uint8_t *_Nullable utf_cipher_name;
-    uint8_t *_Nonnull utf_digest_name;
+    // HMAC
+    BCRYPT_ALG_HANDLE hAlgHmac;
     zeroing_data_t *_Nonnull hmac_key_enc;
     zeroing_data_t *_Nonnull hmac_key_dec;
     UCHAR buffer_iv[IVMaxLength];
@@ -61,35 +55,33 @@ static
 size_t local_encryption_capacity(const void *vctx, size_t input_len) {
     const crypto_cbc_ctx *ctx = (const crypto_cbc_ctx *)vctx;
     pp_assert(ctx);
-    return pp_alloc_crypto_capacity(input_len, ctx->digest_len + ctx->cipher_iv_len);
+    return pp_alloc_crypto_capacity(input_len, ctx->crypto.meta.digest_len + ctx->crypto.meta.cipher_iv_len);
 }
 
 static
 void local_configure_encrypt(void *vctx, const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_cbc_ctx *ctx = (crypto_cbc_ctx *)vctx;
     pp_assert(ctx);
-    pp_assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
+    pp_assert(hmac_key && hmac_key->length >= ctx->crypto.meta.hmac_key_len);
 
     if (ctx->hKeyEnc) {
         BCryptDestroyKey(ctx->hKeyEnc);
         ctx->hKeyEnc = NULL;
     }
     if (ctx->hAlgCipher) {
-        NTSTATUS status = BCryptGenerateSymmetricKey(
+        CRYPTO_ASSERT(BCryptGenerateSymmetricKey(
             ctx->hAlgCipher,
             &ctx->hKeyEnc,
             NULL, 0,
             (PUCHAR)cipher_key->bytes,
-            (ULONG)ctx->cipher_key_len,
+            (ULONG)ctx->crypto.meta.cipher_key_len,
             0
-        );
-        pp_assert(CRYPTO_CNG_SUCCESS(status));
+        ))
     }
-
     if (ctx->hmac_key_enc) {
         zd_free(ctx->hmac_key_enc);
     }
-    ctx->hmac_key_enc = zd_create_from_data(hmac_key->bytes, ctx->hmac_key_len);
+    ctx->hmac_key_enc = zd_create_from_data(hmac_key->bytes, ctx->crypto.meta.hmac_key_len);
 }
 
 static
@@ -101,60 +93,52 @@ size_t local_encrypt(void *vctx,
     pp_assert(ctx);
     pp_assert(ctx->hmac_key_enc);
 
-    uint8_t *out_iv = out + ctx->digest_len;
-    uint8_t *out_encrypted = out_iv + ctx->cipher_iv_len;
+    uint8_t *out_iv = out + ctx->crypto.meta.digest_len;
+    uint8_t *out_encrypted = out_iv + ctx->crypto.meta.cipher_iv_len;
     ULONG enc_len = 0;
     size_t hmac_len = 0;
 
-    NTSTATUS status;
-
     if (ctx->hAlgCipher) {
         if (!flags || !flags->for_testing) {
-            if (!CRYPTO_CNG_SUCCESS(
-                BCryptGenRandom(
-                    NULL,
-                    out_iv,
-                    (ULONG)ctx->cipher_iv_len,
-                    BCRYPT_USE_SYSTEM_PREFERRED_RNG
-                )
-            )) {
-                return 0;
-            }
+            CRYPTO_CHECK(BCryptGenRandom(
+                NULL,
+                out_iv,
+                (ULONG)ctx->crypto.meta.cipher_iv_len,
+                BCRYPT_USE_SYSTEM_PREFERRED_RNG
+            ))
         }
 
         // do NOT use out_iv directly because BCryptEncrypt has side-effect
-        memcpy(ctx->buffer_iv, out_iv, ctx->cipher_iv_len);
+        memcpy(ctx->buffer_iv, out_iv, ctx->crypto.meta.cipher_iv_len);
 
-        CRYPTO_CNG_TRACK_STATUS(status) BCryptEncrypt(
+        CRYPTO_CHECK(BCryptEncrypt(
             ctx->hKeyEnc,
             (PUCHAR)in, (ULONG)in_len,
             NULL,
-            ctx->buffer_iv, (ULONG)ctx->cipher_iv_len,
+            ctx->buffer_iv, (ULONG)ctx->crypto.meta.cipher_iv_len,
             out_encrypted, out_buf_len - (out_encrypted - out),
             &enc_len,
             BCRYPT_BLOCK_PADDING
-        );
-        CRYPTO_CNG_RETURN_IF_FAILED(status, CryptoErrorEncryption)
+        ))
     } else {
         pp_assert(out_encrypted == out_iv);
         memcpy(out_encrypted, in, in_len);
         enc_len = in_len;
     }
 
-    CRYPTO_CNG_TRACK_STATUS(status) BCryptCreateHash(
+    BCRYPT_HASH_HANDLE hHmac = NULL;
+    CRYPTO_CHECK_MAC(BCryptCreateHash(
         ctx->hAlgHmac,
-        &ctx->hHmacEnc,
+        &hHmac,
         NULL, 0,
-        ctx->hmac_key_enc->bytes, (ULONG)ctx->hmac_key_len,
+        ctx->hmac_key_enc->bytes, (ULONG)ctx->crypto.meta.hmac_key_len,
         0
-    );
-    CRYPTO_CNG_TRACK_STATUS(status) BCryptHashData(ctx->hHmacEnc, out_iv, (ULONG)(enc_len + ctx->cipher_iv_len), 0);
-    CRYPTO_CNG_TRACK_STATUS(status) BCryptFinishHash(ctx->hHmacEnc, out, (ULONG)ctx->digest_len, 0);
-    BCryptDestroyHash(ctx->hHmacEnc);
-    ctx->hHmacEnc = NULL;
-    CRYPTO_CNG_RETURN_IF_FAILED(status, CryptoErrorEncryption)
+    ))
+    CRYPTO_CHECK_MAC(BCryptHashData(hHmac, out_iv, (ULONG)(enc_len + ctx->crypto.meta.cipher_iv_len), 0))
+    CRYPTO_CHECK_MAC(BCryptFinishHash(hHmac, out, (ULONG)ctx->crypto.meta.digest_len, 0))
+    BCryptDestroyHash(hHmac);
 
-    const size_t out_len = enc_len + ctx->cipher_iv_len + ctx->digest_len;
+    const size_t out_len = enc_len + ctx->crypto.meta.cipher_iv_len + ctx->crypto.meta.digest_len;
     return out_len;
 }
 
@@ -162,28 +146,26 @@ static
 void local_configure_decrypt(void *vctx, const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_cbc_ctx *ctx = (crypto_cbc_ctx *)vctx;
     pp_assert(ctx);
-    pp_assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
+    pp_assert(hmac_key && hmac_key->length >= ctx->crypto.meta.hmac_key_len);
 
     if (ctx->hKeyDec) {
         BCryptDestroyKey(ctx->hKeyDec);
         ctx->hKeyDec = NULL;
     }
     if (ctx->hAlgCipher) {
-        NTSTATUS status = BCryptGenerateSymmetricKey(
+        CRYPTO_ASSERT(BCryptGenerateSymmetricKey(
             ctx->hAlgCipher,
             &ctx->hKeyDec,
             NULL, 0,
             (PUCHAR)cipher_key->bytes,
-            (ULONG)ctx->cipher_key_len,
+            (ULONG)ctx->crypto.meta.cipher_key_len,
             0
-        );
-        pp_assert(CRYPTO_CNG_SUCCESS(status));
+        ))
     }
-
     if (ctx->hmac_key_dec) {
         zd_free(ctx->hmac_key_dec);
     }
-    ctx->hmac_key_dec = zd_create_from_data(hmac_key->bytes, ctx->hmac_key_len);
+    ctx->hmac_key_dec = zd_create_from_data(hmac_key->bytes, ctx->crypto.meta.hmac_key_len);
 }
 
 static
@@ -196,47 +178,42 @@ size_t local_decrypt(void *vctx,
     pp_assert(ctx);
     pp_assert(ctx->hmac_key_dec);
 
-    const uint8_t *iv = in + ctx->digest_len;
-    const uint8_t *encrypted = in + ctx->digest_len + ctx->cipher_iv_len;
+    const uint8_t *iv = in + ctx->crypto.meta.digest_len;
+    const uint8_t *encrypted = in + ctx->crypto.meta.digest_len + ctx->crypto.meta.cipher_iv_len;
     ULONG dec_len = 0;
     size_t hmac_len = 0;
 
-    // HMAC verify
-    NTSTATUS status;
-    CRYPTO_CNG_TRACK_STATUS(status) BCryptCreateHash(
+    BCRYPT_HASH_HANDLE hHmac = NULL;
+    CRYPTO_CHECK(BCryptCreateHash(
         ctx->hAlgHmac,
-        &ctx->hHmacDec,
+        &hHmac,
         NULL, 0,
-        ctx->hmac_key_dec->bytes, (ULONG)ctx->hmac_key_len,
+        ctx->hmac_key_dec->bytes, (ULONG)ctx->crypto.meta.hmac_key_len,
         0
-    );
-    CRYPTO_CNG_TRACK_STATUS(status) BCryptHashData(ctx->hHmacDec, (PUCHAR)(in + ctx->digest_len), (ULONG)(in_len - ctx->digest_len), 0);
-    CRYPTO_CNG_TRACK_STATUS(status) BCryptFinishHash(ctx->hHmacDec, ctx->buffer_hmac, (ULONG)ctx->digest_len, 0);
-    BCryptDestroyHash(ctx->hHmacDec);
-    ctx->hHmacDec = NULL;
-    CRYPTO_CNG_RETURN_IF_FAILED(status, CryptoErrorEncryption)
+    ))
+    CRYPTO_CHECK(BCryptHashData(hHmac, (PUCHAR)(in + ctx->crypto.meta.digest_len), (ULONG)(in_len - ctx->crypto.meta.digest_len), 0))
+    CRYPTO_CHECK(BCryptFinishHash(hHmac, ctx->buffer_hmac, (ULONG)ctx->crypto.meta.digest_len, 0))
+    BCryptDestroyHash(hHmac);
 
-    if (memcmp(ctx->buffer_hmac, in, ctx->digest_len) != 0) {
+    if (memcmp(ctx->buffer_hmac, in, ctx->crypto.meta.digest_len) != 0) {
         if (error) *error = CryptoErrorHMAC;
         return 0;
     }
 
     ULONG out_len = 0;
     if (ctx->hAlgCipher) {
-        // Decrypt with CNG padding
-        CRYPTO_CNG_TRACK_STATUS(status) BCryptDecrypt(
+        CRYPTO_CHECK(BCryptDecrypt(
             ctx->hKeyDec,
-            (PUCHAR)encrypted, (ULONG)(in_len - ctx->digest_len - ctx->cipher_iv_len),
+            (PUCHAR)encrypted, (ULONG)(in_len - ctx->crypto.meta.digest_len - ctx->crypto.meta.cipher_iv_len),
             NULL,
-            (PUCHAR)iv, (ULONG)ctx->cipher_iv_len,
+            (PUCHAR)iv, (ULONG)ctx->crypto.meta.cipher_iv_len,
             out, out_buf_len,
             &out_len,
             BCRYPT_BLOCK_PADDING
-        );
-        CRYPTO_CNG_RETURN_IF_FAILED(status, CryptoErrorEncryption)
+        ))
     } else {
-        memcpy(out, in + ctx->digest_len, in_len - ctx->digest_len);
-        out_len = in_len - ctx->digest_len;
+        memcpy(out, in + ctx->crypto.meta.digest_len, in_len - ctx->crypto.meta.digest_len);
+        out_len = in_len - ctx->crypto.meta.digest_len;
     }
     return out_len;
 }
@@ -246,22 +223,20 @@ bool local_verify(void *vctx, const uint8_t *in, size_t in_len, crypto_error_cod
     crypto_cbc_ctx *ctx = (crypto_cbc_ctx *)vctx;
     pp_assert(ctx);
     size_t hmac_len = 0;
-    NTSTATUS status;
 
-    CRYPTO_CNG_TRACK_STATUS(status) BCryptCreateHash(
+    BCRYPT_HASH_HANDLE hHmac = NULL;
+    CRYPTO_CHECK_MAC(BCryptCreateHash(
         ctx->hAlgHmac,
-        &ctx->hHmacDec,
+        &hHmac,
         NULL, 0,
-        ctx->hmac_key_dec->bytes, (ULONG)ctx->hmac_key_len,
+        ctx->hmac_key_dec->bytes, (ULONG)ctx->crypto.meta.hmac_key_len,
         0
-    );
-    CRYPTO_CNG_TRACK_STATUS(status) BCryptHashData(ctx->hHmacDec, (PUCHAR)(in + ctx->digest_len), (ULONG)(in_len - ctx->digest_len), 0);
-    CRYPTO_CNG_TRACK_STATUS(status) BCryptFinishHash(ctx->hHmacDec, ctx->buffer_hmac, (ULONG)ctx->digest_len, 0);
-    BCryptDestroyHash(ctx->hHmacDec);
-    ctx->hHmacDec = NULL;
-    CRYPTO_CNG_RETURN_IF_FAILED(status, CryptoErrorEncryption)
+    ))
+    CRYPTO_CHECK_MAC(BCryptHashData(hHmac, (PUCHAR)(in + ctx->crypto.meta.digest_len), (ULONG)(in_len - ctx->crypto.meta.digest_len), 0))
+    CRYPTO_CHECK_MAC(BCryptFinishHash(hHmac, ctx->buffer_hmac, (ULONG)ctx->crypto.meta.digest_len, 0))
+    BCryptDestroyHash(hHmac);
 
-    if (memcmp(ctx->buffer_hmac, in, ctx->digest_len) != 0) {
+    if (memcmp(ctx->buffer_hmac, in, ctx->crypto.meta.digest_len) != 0) {
         if (error) *error = CryptoErrorHMAC;
         return false;
     }
@@ -307,53 +282,37 @@ crypto_ctx crypto_cbc_create(const char *cipher_name, const char *digest_name,
     }
 
     crypto_cbc_ctx *ctx = pp_alloc_crypto(sizeof(crypto_cbc_ctx));
-    if (!ctx) {
-        return NULL;
-    }
 
-    ctx->cipher_key_len = cipher_key_len;
-    ctx->cipher_iv_len = cipher_iv_len;
-    ctx->hmac_key_len = hmac_key_len;
-    ctx->digest_len = ctx->hmac_key_len;
-
-    ctx->utf_cipher_name = NULL;
-    ctx->utf_digest_name = NULL;
-    ctx->hKeyEnc = NULL;
-    ctx->hKeyDec = NULL;
-    ctx->hHmacEnc = NULL;
-    ctx->hHmacDec = NULL;
-
-    NTSTATUS status;
     if (cipher_name) {
-        CRYPTO_CNG_TRACK_STATUS(status) BCryptOpenAlgorithmProvider(
+        CRYPTO_CHECK_CREATE(BCryptOpenAlgorithmProvider(
             &ctx->hAlgCipher,
             BCRYPT_AES_ALGORITHM,
             NULL,
             0
-        );
-        CRYPTO_CNG_TRACK_STATUS(status) BCryptSetProperty(
+        ));
+        CRYPTO_CHECK_CREATE(BCryptSetProperty(
             ctx->hAlgCipher,
             BCRYPT_CHAINING_MODE,
             (PUCHAR)BCRYPT_CHAIN_MODE_CBC,
             (ULONG)sizeof(BCRYPT_CHAIN_MODE_CBC),
             0
-        );
-        CRYPTO_CNG_CLOSE_IF_FAILED(status, ctx->hAlgCipher)
+        ));
     } else {
         ctx->hAlgCipher = NULL;
     }
-    CRYPTO_CNG_TRACK_STATUS(status) BCryptOpenAlgorithmProvider(
+    CRYPTO_CHECK_CREATE(BCryptOpenAlgorithmProvider(
         &ctx->hAlgHmac,
         hmac_alg_id,
         NULL,
         BCRYPT_ALG_HANDLE_HMAC_FLAG
-    );
-    CRYPTO_CNG_CLOSE_IF_FAILED(status, ctx->hAlgCipher)
+    ));
 
-    ctx->crypto.meta.cipher_key_len = ctx->cipher_key_len;
-    ctx->crypto.meta.cipher_iv_len = ctx->cipher_iv_len;
-    ctx->crypto.meta.hmac_key_len = ctx->hmac_key_len;
-    ctx->crypto.meta.digest_len = ctx->digest_len;
+    // no longer fails
+
+    ctx->crypto.meta.cipher_key_len = cipher_key_len;
+    ctx->crypto.meta.cipher_iv_len = cipher_iv_len;
+    ctx->crypto.meta.hmac_key_len = hmac_key_len;
+    ctx->crypto.meta.digest_len = hmac_key_len;
     ctx->crypto.meta.tag_len = 0;
     ctx->crypto.meta.encryption_capacity = local_encryption_capacity;
 
@@ -369,6 +328,11 @@ crypto_ctx crypto_cbc_create(const char *cipher_name, const char *digest_name,
     }
 
     return (crypto_ctx)ctx;
+
+failure:
+    if (ctx->hAlgCipher) BCryptCloseAlgorithmProvider(ctx->hAlgCipher, 0);
+    free(ctx);
+    return NULL;
 }
 
 void crypto_cbc_free(crypto_ctx vctx) {
@@ -378,10 +342,12 @@ void crypto_cbc_free(crypto_ctx vctx) {
     if (ctx->hKeyEnc) BCryptDestroyKey(ctx->hKeyEnc);
     if (ctx->hKeyDec) BCryptDestroyKey(ctx->hKeyDec);
     if (ctx->hAlgCipher) BCryptCloseAlgorithmProvider(ctx->hAlgCipher, 0);
-    if (ctx->hAlgHmac) BCryptCloseAlgorithmProvider(ctx->hAlgHmac, 0);
+
+    if (ctx->hmac_key_enc) zd_free(ctx->hmac_key_enc);
+    if (ctx->hmac_key_dec) zd_free(ctx->hmac_key_dec);
+    BCryptCloseAlgorithmProvider(ctx->hAlgHmac, 0);
     pp_zero(ctx->buffer_iv, sizeof(ctx->buffer_iv));
     pp_zero(ctx->buffer_hmac, sizeof(ctx->buffer_hmac));
-    zd_free(ctx->hmac_key_enc);
-    zd_free(ctx->hmac_key_dec);
+
     free(ctx);
 } 

--- a/Sources/Crypto/Windows_C/crypto_cbc.c
+++ b/Sources/Crypto/Windows_C/crypto_cbc.c
@@ -196,7 +196,7 @@ size_t local_decrypt(void *vctx,
     BCryptDestroyHash(hHmac);
 
     if (memcmp(ctx->buffer_hmac, in, ctx->crypto.meta.digest_len) != 0) {
-        if (error) *error = CryptoErrorHMAC;
+        CRYPTO_SET_ERROR(CryptoErrorHMAC)
         return 0;
     }
 
@@ -237,7 +237,7 @@ bool local_verify(void *vctx, const uint8_t *in, size_t in_len, crypto_error_cod
     BCryptDestroyHash(hHmac);
 
     if (memcmp(ctx->buffer_hmac, in, ctx->crypto.meta.digest_len) != 0) {
-        if (error) *error = CryptoErrorHMAC;
+        CRYPTO_SET_ERROR(CryptoErrorHMAC)
         return false;
     }
     return true;

--- a/Sources/Crypto/Windows_C/crypto_cbc.c
+++ b/Sources/Crypto/Windows_C/crypto_cbc.c
@@ -61,15 +61,15 @@ typedef struct {
 static
 size_t local_encryption_capacity(const void *vctx, size_t input_len) {
     const crypto_cbc_ctx *ctx = (const crypto_cbc_ctx *)vctx;
-    assert(ctx);
+    pp_assert(ctx);
     return pp_alloc_crypto_capacity(input_len, ctx->digest_len + ctx->cipher_iv_len);
 }
 
 static
 void local_configure_encrypt(void *vctx, const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_cbc_ctx *ctx = (crypto_cbc_ctx *)vctx;
-    assert(ctx);
-    assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
+    pp_assert(ctx);
+    pp_assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
 
     if (ctx->hKeyEnc) {
         BCryptDestroyKey(ctx->hKeyEnc);
@@ -84,7 +84,7 @@ void local_configure_encrypt(void *vctx, const zeroing_data_t *cipher_key, const
             (ULONG)ctx->cipher_key_len,
             0
         );
-        assert(CRYPTO_CNG_SUCCESS(status));
+        pp_assert(CRYPTO_CNG_SUCCESS(status));
     }
 
     if (ctx->hmac_key_enc) {
@@ -99,8 +99,8 @@ size_t local_encrypt(void *vctx,
                      const uint8_t *in, size_t in_len,
                      const crypto_flags_t *flags, crypto_error_code *error) {
     crypto_cbc_ctx *ctx = (crypto_cbc_ctx *)vctx;
-    assert(ctx);
-    assert(ctx->hmac_key_enc);
+    pp_assert(ctx);
+    pp_assert(ctx->hmac_key_enc);
 
     uint8_t *out_iv = out + ctx->digest_len;
     uint8_t *out_encrypted = out_iv + ctx->cipher_iv_len;
@@ -137,7 +137,7 @@ size_t local_encrypt(void *vctx,
         );
         CRYPTO_CNG_RETURN_IF_FAILED(status, CryptoErrorEncryption)
     } else {
-        assert(out_encrypted == out_iv);
+        pp_assert(out_encrypted == out_iv);
         memcpy(out_encrypted, in, in_len);
         enc_len = in_len;
     }
@@ -162,8 +162,8 @@ size_t local_encrypt(void *vctx,
 static
 void local_configure_decrypt(void *vctx, const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_cbc_ctx *ctx = (crypto_cbc_ctx *)vctx;
-    assert(ctx);
-    assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
+    pp_assert(ctx);
+    pp_assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
 
     if (ctx->hKeyDec) {
         BCryptDestroyKey(ctx->hKeyDec);
@@ -178,7 +178,7 @@ void local_configure_decrypt(void *vctx, const zeroing_data_t *cipher_key, const
             (ULONG)ctx->cipher_key_len,
             0
         );
-        assert(CRYPTO_CNG_SUCCESS(status));
+        pp_assert(CRYPTO_CNG_SUCCESS(status));
     }
 
     if (ctx->hmac_key_dec) {
@@ -194,8 +194,8 @@ size_t local_decrypt(void *vctx,
                      const crypto_flags_t *flags, crypto_error_code *error) {
     (void)flags;
     crypto_cbc_ctx *ctx = (crypto_cbc_ctx *)vctx;
-    assert(ctx);
-    assert(ctx->hmac_key_dec);
+    pp_assert(ctx);
+    pp_assert(ctx->hmac_key_dec);
 
     const uint8_t *iv = in + ctx->digest_len;
     const uint8_t *encrypted = in + ctx->digest_len + ctx->cipher_iv_len;
@@ -245,7 +245,7 @@ size_t local_decrypt(void *vctx,
 static
 bool local_verify(void *vctx, const uint8_t *in, size_t in_len, crypto_error_code *error) {
     crypto_cbc_ctx *ctx = (crypto_cbc_ctx *)vctx;
-    assert(ctx);
+    pp_assert(ctx);
     size_t hmac_len = 0;
     NTSTATUS status;
 
@@ -273,7 +273,7 @@ bool local_verify(void *vctx, const uint8_t *in, size_t in_len, crypto_error_cod
 
 crypto_ctx crypto_cbc_create(const char *cipher_name, const char *digest_name,
                              const crypto_keys_t *keys) {
-    assert(digest_name);
+    pp_assert(digest_name);
 
     size_t cipher_key_len;
     size_t cipher_iv_len;

--- a/Sources/Crypto/Windows_C/crypto_cbc.c
+++ b/Sources/Crypto/Windows_C/crypto_cbc.c
@@ -23,7 +23,6 @@
 //  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
 #include <windows.h>
 #include <bcrypt.h>
 #include <string.h>

--- a/Sources/Crypto/Windows_C/crypto_ctr.c
+++ b/Sources/Crypto/Windows_C/crypto_ctr.c
@@ -243,7 +243,7 @@ size_t local_decrypt(void *vctx,
     BCryptCloseAlgorithmProvider(hAlgHmac, 0);
 
     if (memcmp(ctx->buffer_hmac, in, ctx->ns_tag_len) != 0) {
-        if (error) *error = CryptoErrorHMAC;
+        CRYPTO_SET_ERROR(CryptoErrorHMAC)
         return 0;
     }
     return out_len;

--- a/Sources/Crypto/Windows_C/crypto_ctr.c
+++ b/Sources/Crypto/Windows_C/crypto_ctr.c
@@ -23,7 +23,6 @@
 //  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
 #include <windows.h>
 #include <bcrypt.h>
 #include <string.h>

--- a/Sources/Crypto/Windows_C/crypto_ctr.c
+++ b/Sources/Crypto/Windows_C/crypto_ctr.c
@@ -64,7 +64,7 @@ void ctr_increment(uint8_t *counter, size_t len) {
 static
 size_t local_encryption_capacity(const void *vctx, size_t len) {
     const crypto_ctr_ctx *ctx = (const crypto_ctr_ctx *)vctx;
-    assert(ctx);
+    pp_assert(ctx);
     return pp_alloc_crypto_capacity(len, ctx->payload_len + ctx->ns_tag_len);
 }
 
@@ -72,9 +72,9 @@ static
 void local_configure_encrypt(void *vctx,
                              const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_ctr_ctx *ctx = (crypto_ctr_ctx *)vctx;
-    assert(ctx);
-    assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
-    assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
+    pp_assert(ctx);
+    pp_assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
+    pp_assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
 
     if (ctx->hKeyEnc) {
         BCryptDestroyKey(ctx->hKeyEnc);
@@ -88,7 +88,7 @@ void local_configure_encrypt(void *vctx,
         (ULONG)ctx->cipher_key_len,
         0
     );
-    assert(CRYPTO_CNG_SUCCESS(status));
+    pp_assert(CRYPTO_CNG_SUCCESS(status));
 
     if (ctx->hmac_key_enc) {
         zd_free(ctx->hmac_key_enc);
@@ -102,10 +102,10 @@ size_t local_encrypt(void *vctx,
                      const uint8_t *in, size_t in_len,
                      const crypto_flags_t *flags, crypto_error_code *error) {
     crypto_ctr_ctx *ctx = (crypto_ctr_ctx *)vctx;
-    assert(ctx);
-    assert(ctx->hKeyEnc);
-    assert(ctx->hmac_key_enc);
-    assert(flags);
+    pp_assert(ctx);
+    pp_assert(ctx->hKeyEnc);
+    pp_assert(ctx->hmac_key_enc);
+    pp_assert(flags);
 
     uint8_t *out_encrypted = out + ctx->ns_tag_len;
     size_t block_size = ctx->cipher_iv_len;
@@ -165,9 +165,9 @@ size_t local_encrypt(void *vctx,
 static
 void local_configure_decrypt(void *vctx, const zeroing_data_t *cipher_key, const zeroing_data_t *hmac_key) {
     crypto_ctr_ctx *ctx = (crypto_ctr_ctx *)vctx;
-    assert(ctx);
-    assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
-    assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
+    pp_assert(ctx);
+    pp_assert(hmac_key && hmac_key->length >= ctx->hmac_key_len);
+    pp_assert(cipher_key && cipher_key->length >= ctx->cipher_key_len);
 
     if (ctx->hKeyDec) {
         BCryptDestroyKey(ctx->hKeyDec);
@@ -181,7 +181,7 @@ void local_configure_decrypt(void *vctx, const zeroing_data_t *cipher_key, const
         (ULONG)ctx->cipher_key_len,
         0
     );
-    assert(CRYPTO_CNG_SUCCESS(status));
+    pp_assert(CRYPTO_CNG_SUCCESS(status));
 
     if (ctx->hmac_key_dec) {
         zd_free(ctx->hmac_key_dec);
@@ -195,10 +195,10 @@ size_t local_decrypt(void *vctx,
                      const uint8_t *in, size_t in_len,
                      const crypto_flags_t *flags, crypto_error_code *error) {
     crypto_ctr_ctx *ctx = (crypto_ctr_ctx *)vctx;
-    assert(ctx);
-    assert(ctx->hKeyDec);
-    assert(ctx->hmac_key_dec);
-    assert(flags);
+    pp_assert(ctx);
+    pp_assert(ctx->hKeyDec);
+    pp_assert(ctx->hmac_key_dec);
+    pp_assert(flags);
 
     const uint8_t *iv = in;
     const uint8_t *encrypted = in + ctx->ns_tag_len;
@@ -268,7 +268,7 @@ size_t local_decrypt(void *vctx,
 crypto_ctx crypto_ctr_create(const char *cipher_name, const char *digest_name,
                              size_t tag_len, size_t payload_len,
                              const crypto_keys_t *keys) {
-    assert(cipher_name && digest_name);
+    pp_assert(cipher_name && digest_name);
 
     // Only AES-CTR and HMAC-SHA256 supported
     if (_stricmp(cipher_name, "AES-128-CTR")) {

--- a/Sources/Crypto/Windows_C/include/macros.h
+++ b/Sources/Crypto/Windows_C/include/macros.h
@@ -25,22 +25,27 @@
 
 #pragma once
 
-#define CRYPTO_CNG_SUCCESS(status) (BCRYPT_SUCCESS(status))
+#define CRYPTO_ASSERT(status) pp_assert(BCRYPT_SUCCESS(status));
 
-#define CRYPTO_CNG_TRACK_STATUS(status) if (BCRYPT_SUCCESS(status)) status =
+#define CRYPTO_CHECK_CREATE(status) if (!BCRYPT_SUCCESS(status)) goto failure;
 
-#define CRYPTO_CNG_CLOSE_IF_FAILED(status, hAlg)\
+#define CRYPTO_CHECK(status)\
 if (!BCRYPT_SUCCESS(status)) {\
-    if (hAlg) {\
-        BCryptCloseAlgorithmProvider(hAlg, 0);\
-    }\
-    return NULL;\
+    if (error) *error = CryptoErrorEncryption;\
+    return 0;\
 }
 
-#define CRYPTO_CNG_RETURN_IF_FAILED(status, raised)\
+#define CRYPTO_CHECK_MAC(status)\
 if (!BCRYPT_SUCCESS(status)) {\
-    if (error) {\
-        *error = raised;\
-    }\
+    if (error) *error = CryptoErrorHMAC;\
+    if (hHmac) BCryptDestroyHash(hHmac);\
+    return 0;\
+}
+
+#define CRYPTO_CHECK_MAC_ALG(status)\
+if (!BCRYPT_SUCCESS(status)) {\
+    if (error) *error = CryptoErrorHMAC;\
+    if (hHmac) BCryptDestroyHash(hHmac);\
+    if (hAlgHmac) BCryptCloseAlgorithmProvider(hAlgHmac, 0);\
     return 0;\
 }

--- a/Sources/Crypto/Windows_C/include/macros.h
+++ b/Sources/Crypto/Windows_C/include/macros.h
@@ -25,27 +25,30 @@
 
 #pragma once
 
-#define CRYPTO_ASSERT(status) pp_assert(BCRYPT_SUCCESS(status));
+#define CRYPTO_ASSERT(ntstatus) pp_assert(BCRYPT_SUCCESS(ntstatus));
 
-#define CRYPTO_CHECK_CREATE(status) if (!BCRYPT_SUCCESS(status)) goto failure;
+#define CRYPTO_CHECK_CREATE(ntstatus) if (!BCRYPT_SUCCESS(ntstatus)) goto failure;
 
-#define CRYPTO_CHECK(status)\
-if (!BCRYPT_SUCCESS(status)) {\
+#define CRYPTO_CHECK(ntstatus)\
+if (!BCRYPT_SUCCESS(ntstatus)) {\
     if (error) *error = CryptoErrorEncryption;\
     return 0;\
 }
 
-#define CRYPTO_CHECK_MAC(status)\
-if (!BCRYPT_SUCCESS(status)) {\
+#define CRYPTO_CHECK_MAC(ntstatus)\
+if (!BCRYPT_SUCCESS(ntstatus)) {\
     if (error) *error = CryptoErrorHMAC;\
     if (hHmac) BCryptDestroyHash(hHmac);\
     return 0;\
 }
 
-#define CRYPTO_CHECK_MAC_ALG(status)\
-if (!BCRYPT_SUCCESS(status)) {\
+#define CRYPTO_CHECK_MAC_ALG(ntstatus)\
+if (!BCRYPT_SUCCESS(ntstatus)) {\
     if (error) *error = CryptoErrorHMAC;\
     if (hHmac) BCryptDestroyHash(hHmac);\
     if (hAlgHmac) BCryptCloseAlgorithmProvider(hAlgHmac, 0);\
     return 0;\
 }
+
+#define CRYPTO_SET_ERROR(crypto_code)\
+if (error) *error = crypto_code;\

--- a/Sources/OpenVPN/OpenVPN_C/control.c
+++ b/Sources/OpenVPN/OpenVPN_C/control.c
@@ -23,7 +23,6 @@
 //  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
 #include <string.h>
 #include "crypto/allocation.h"
 #include "openvpn/control.h"

--- a/Sources/OpenVPN/OpenVPN_C/control.c
+++ b/Sources/OpenVPN/OpenVPN_C/control.c
@@ -49,7 +49,7 @@ ctrl_pkt_t *_Nonnull ctrl_pkt_create(packet_code code, uint8_t key, uint32_t pac
         pkt->payload_len = 0;
     }
     if (ack_ids) {
-        assert(ack_remote_session_id);
+        pp_assert(ack_remote_session_id);
         const size_t ack_len = ack_ids_len * sizeof(uint32_t);
         pkt->ack_ids = pp_alloc_crypto(ack_len);
         pkt->ack_ids_len = ack_ids_len;
@@ -91,7 +91,7 @@ size_t ctrl_pkt_is_ack(const ctrl_pkt_t *pkt) {
 static inline
 size_t ctrl_pkt_raw_capacity(const ctrl_pkt_t *pkt) {
     const bool is_ack = ctrl_pkt_is_ack(pkt);
-    assert(!is_ack || pkt->ack_ids);//, @"Ack packet must provide positive ackLength");
+    pp_assert(!is_ack || pkt->ack_ids);//, @"Ack packet must provide positive ackLength");
     size_t n = PacketAckLengthLength;
     if (pkt->ack_ids) {
         n += pkt->ack_ids_len * PacketIdLength + PacketSessionIdLength;
@@ -125,7 +125,7 @@ size_t ctrl_pkt_serialize(uint8_t *_Nonnull dst, const ctrl_pkt_t *_Nonnull pkt)
             *(uint32_t *)ptr = endian_htonl(ack_id);
             ptr += PacketIdLength;
         }
-        assert(pkt->ack_remote_session_id);
+        pp_assert(pkt->ack_remote_session_id);
         memcpy(ptr, pkt->ack_remote_session_id, PacketSessionIdLength);
         ptr += PacketSessionIdLength;
     } else {
@@ -172,7 +172,7 @@ size_t ctrl_pkt_serialize_auth(uint8_t *dst,
     if (!dst_len) {
         return 0;
     }
-    assert(dst_len == digest_len + subject_len);//, @"Encrypted packet size != (Digest + Subject)");
+    pp_assert(dst_len == digest_len + subject_len);//, @"Encrypted packet size != (Digest + Subject)");
     data_swap(dst, digest_len + PacketReplayIdLength + PacketReplayTimestampLength, PacketOpcodeLength + PacketSessionIdLength);
     return dst_len;
 }

--- a/Sources/OpenVPN/OpenVPN_C/dp_mode_ad.c
+++ b/Sources/OpenVPN/OpenVPN_C/dp_mode_ad.c
@@ -36,7 +36,7 @@ size_t dp_assemble(void *vmode) {
     const dp_mode_assemble_ctx *ctx = &mode->assemble_ctx;
 
     const size_t dst_capacity = dp_mode_assemble_capacity(mode, ctx->src_len);
-    assert(ctx->dst->length >= dst_capacity);
+    pp_assert(ctx->dst->length >= dst_capacity);
 
     uint8_t *dst = ctx->dst->bytes;
     size_t dst_len = ctx->src_len;
@@ -62,11 +62,11 @@ size_t dp_encrypt(void *vmode) {
     const dp_mode_t *mode = vmode;
     const dp_mode_encrypt_ctx *ctx = &mode->enc_ctx;
 
-    assert(mode->enc.raw_encrypt);
+    pp_assert(mode->enc.raw_encrypt);
     DP_ENCRYPT_BEGIN(mode->opt.peer_id)
 
     const size_t dst_capacity = dp_mode_encrypt_capacity(mode, ctx->src_len);
-    assert(ctx->dst->length >= dst_capacity);
+    pp_assert(ctx->dst->length >= dst_capacity);
     uint8_t *dst = ctx->dst->bytes;
 
     *(uint32_t *)(dst + dst_header_len) = endian_htonl(ctx->packet_id);
@@ -95,7 +95,7 @@ size_t dp_encrypt(void *vmode) {
                                                         &flags,
                                                         &enc_error);
 
-    assert(dst_packet_len <= dst_capacity);//, "Did not allocate enough bytes for payload");
+    pp_assert(dst_packet_len <= dst_capacity);//, "Did not allocate enough bytes for payload");
 
     if (!dst_packet_len) {
         if (ctx->error) {
@@ -113,9 +113,9 @@ size_t dp_decrypt(void *vmode) {
     const dp_mode_t *mode = vmode;
     const dp_mode_decrypt_ctx *ctx = &mode->dec_ctx;
 
-    assert(mode->dec.raw_decrypt);
-    assert(ctx->src_len > 0);//, @"Decrypting an empty packet, how did it get this far?");
-    assert(ctx->dst->length >= ctx->src_len);
+    pp_assert(mode->dec.raw_decrypt);
+    pp_assert(ctx->src_len > 0);//, @"Decrypting an empty packet, how did it get this far?");
+    pp_assert(ctx->dst->length >= ctx->src_len);
     uint8_t *dst = ctx->dst->bytes;
 
     DP_DECRYPT_BEGIN(ctx)
@@ -168,7 +168,7 @@ size_t dp_parse(void *vmode) {
     const dp_mode_t *mode = vmode;
     const dp_mode_parse_ctx *ctx = &mode->parse_ctx;
 
-    assert(ctx->dst->length >= ctx->src_len);
+    pp_assert(ctx->dst->length >= ctx->src_len);
 
     uint8_t *payload = ctx->src;
     size_t dst_len = ctx->src_len;// - (int)(payload - ctx->src);

--- a/Sources/OpenVPN/OpenVPN_C/dp_mode_ad.c
+++ b/Sources/OpenVPN/OpenVPN_C/dp_mode_ad.c
@@ -23,7 +23,6 @@
 //  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
 #include "crypto/endian.h"
 #include "openvpn/dp_macros.h"
 #include "openvpn/dp_mode_ad.h"

--- a/Sources/OpenVPN/OpenVPN_C/dp_mode_hmac.c
+++ b/Sources/OpenVPN/OpenVPN_C/dp_mode_hmac.c
@@ -37,7 +37,7 @@ size_t dp_assemble(void *vmode) {
     const dp_mode_assemble_ctx *ctx = &mode->assemble_ctx;
 
     const size_t dst_capacity = dp_mode_assemble_capacity(mode, ctx->src_len);
-    assert(ctx->dst->length >= dst_capacity);
+    pp_assert(ctx->dst->length >= dst_capacity);
 
     uint8_t *dst = ctx->dst->bytes;
     *(uint32_t *)dst = endian_htonl(ctx->packet_id);
@@ -65,11 +65,11 @@ size_t dp_encrypt(void *vmode) {
     const dp_mode_t *mode = vmode;
     const dp_mode_encrypt_ctx *ctx = &mode->enc_ctx;
 
-    assert(mode->enc.raw_encrypt);
+    pp_assert(mode->enc.raw_encrypt);
     DP_ENCRYPT_BEGIN(mode->opt.peer_id)
 
     const size_t dst_capacity = dp_mode_encrypt_capacity(mode, ctx->src_len);
-    assert(ctx->dst->length >= dst_capacity);
+    pp_assert(ctx->dst->length >= dst_capacity);
     uint8_t *dst = ctx->dst->bytes;
 
     // skip header bytes
@@ -82,7 +82,7 @@ size_t dp_encrypt(void *vmode) {
                                                         NULL,
                                                         &enc_error);
 
-    assert(dst_packet_len <= dst_capacity);//, @"Did not allocate enough bytes for payload");
+    pp_assert(dst_packet_len <= dst_capacity);//, @"Did not allocate enough bytes for payload");
 
     if (!dst_packet_len) {
         if (ctx->error) {
@@ -105,9 +105,9 @@ size_t dp_decrypt(void *vmode) {
     const dp_mode_t *mode = vmode;
     const dp_mode_decrypt_ctx *ctx = &mode->dec_ctx;
 
-    assert(mode->dec.raw_decrypt);
-    assert(ctx->src_len > 0);//, @"Decrypting an empty packet, how did it get this far?");
-    assert(ctx->dst->length >= ctx->src_len);
+    pp_assert(mode->dec.raw_decrypt);
+    pp_assert(ctx->src_len > 0);//, @"Decrypting an empty packet, how did it get this far?");
+    pp_assert(ctx->dst->length >= ctx->src_len);
     uint8_t *dst = ctx->dst->bytes;
 
     DP_DECRYPT_BEGIN(ctx)
@@ -151,7 +151,7 @@ size_t dp_parse(void *vmode) {
     const dp_mode_t *mode = vmode;
     const dp_mode_parse_ctx *ctx = &mode->parse_ctx;
 
-    assert(ctx->dst->length >= ctx->src_len);
+    pp_assert(ctx->dst->length >= ctx->src_len);
 
     uint8_t *payload = ctx->src;
     payload += sizeof(uint32_t); // packet id

--- a/Sources/OpenVPN/OpenVPN_C/dp_mode_hmac.c
+++ b/Sources/OpenVPN/OpenVPN_C/dp_mode_hmac.c
@@ -23,7 +23,6 @@
 //  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
 #include <stdint.h>
 #include "crypto/endian.h"
 #include "openvpn/dp_macros.h"

--- a/Sources/OpenVPN/OpenVPN_C/include/openvpn/dp_mode.h
+++ b/Sources/OpenVPN/OpenVPN_C/include/openvpn/dp_mode.h
@@ -222,7 +222,7 @@ zeroing_data_t *_Nullable dp_mode_assemble_and_encrypt(dp_mode_t *_Nonnull mode,
                                                        size_t src_len,
                                                        dp_error_t *_Nullable error) {
 
-    assert(buf->length >= dp_mode_assemble_and_encrypt_capacity(mode, src_len));
+    pp_assert(buf->length >= dp_mode_assemble_and_encrypt_capacity(mode, src_len));
     const size_t asm_len = dp_mode_assemble(mode, packet_id, buf,
                                             src, src_len);
     if (!asm_len) {
@@ -265,7 +265,7 @@ zeroing_data_t *_Nullable dp_mode_decrypt_and_parse(dp_mode_t *_Nonnull mode,
                                                     size_t src_len,
                                                     dp_error_t *_Nullable error) {
 
-    assert(buf->length >= src_len);
+    pp_assert(buf->length >= src_len);
     const size_t dec_len = dp_mode_decrypt(mode, buf, dst_packet_id,
                                            src, src_len, error);
     if (!dec_len) {
@@ -279,7 +279,7 @@ zeroing_data_t *_Nullable dp_mode_decrypt_and_parse(dp_mode_t *_Nonnull mode,
         return NULL;
     }
     zd_resize(dst, dst_len);
-    assert(dst->length == dst_len);
+    pp_assert(dst->length == dst_len);
     if (packet_is_ping(dst->bytes, dst->length)) {
         *dst_keep_alive = true;
     }

--- a/Sources/OpenVPN/OpenVPN_C/include/openvpn/obf.h
+++ b/Sources/OpenVPN/OpenVPN_C/include/openvpn/obf.h
@@ -37,7 +37,7 @@ void obf_xor_mask(uint8_t *_Nonnull dst,
                   const uint8_t *_Nonnull mask,
                   size_t mask_len) {
 
-    assert(mask && mask_len > 0);
+    pp_assert(mask && mask_len > 0);
     if (mask_len == 0) {
         return;
     }

--- a/Sources/OpenVPN/OpenVPN_C/include/openvpn/packet.h
+++ b/Sources/OpenVPN/OpenVPN_C/include/openvpn/packet.h
@@ -38,6 +38,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include "crypto/allocation.h"
 #include "crypto/endian.h"
 
 // MARK: - Packets

--- a/Sources/OpenVPN/OpenVPN_C/include/openvpn/packet.h
+++ b/Sources/OpenVPN/OpenVPN_C/include/openvpn/packet.h
@@ -36,7 +36,6 @@
 
 #pragma once
 
-#include <assert.h>
 #include <stdint.h>
 #include <string.h>
 #include "crypto/endian.h"

--- a/Sources/OpenVPN/OpenVPN_C/include/openvpn/packet.h
+++ b/Sources/OpenVPN/OpenVPN_C/include/openvpn/packet.h
@@ -143,7 +143,7 @@ void data_swap(uint8_t *_Nonnull ptr, size_t len1, size_t len2)
 
 static inline
 void data_swap_copy(uint8_t *_Nonnull dst, const uint8_t *_Nonnull src, size_t src_len, size_t len1, size_t len2) {
-    assert(src_len >= len1 + len2);//, @"src is smaller than expected");
+    pp_assert(src_len >= len1 + len2);//, @"src is smaller than expected");
     memcpy(dst, src + len1, len2);
     memcpy(dst + len2, src, len1);
     const size_t preamble_len = len1 + len2;

--- a/Sources/OpenVPN/OpenVPN_C/include/openvpn/pkt_proc.h
+++ b/Sources/OpenVPN/OpenVPN_C/include/openvpn/pkt_proc.h
@@ -146,7 +146,7 @@ size_t pkt_proc_stream_send(const void *_Nonnull vproc,
                             size_t src_len) {
 
     const size_t buf_len = pkt_proc_stream_header_len + src_len;
-    assert(dst->length >= dst_offset + buf_len);
+    pp_assert(dst->length >= dst_offset + buf_len);
 
     uint8_t *ptr = dst->bytes + dst_offset;
     *(uint16_t *)ptr = endian_htons(src_len);

--- a/Sources/OpenVPN/OpenVPN_C/pkt_proc.c
+++ b/Sources/OpenVPN/OpenVPN_C/pkt_proc.c
@@ -34,13 +34,13 @@
 
 static inline
 void alg_plain(const pkt_proc_alg_ctx *ctx) {
-    assert(ctx);
+    pp_assert(ctx);
     memcpy(ctx->dst + ctx->dst_offset, ctx->src + ctx->src_offset, ctx->src_len);
 }
 
 static
 void alg_xor_mask(const pkt_proc_alg_ctx *ctx) {
-    assert(ctx->mask && ctx->mask_len);
+    pp_assert(ctx->mask && ctx->mask_len);
     alg_plain(ctx);
     obf_xor_mask(ctx->dst + ctx->dst_offset, ctx->src_len, ctx->mask, ctx->mask_len);
 }
@@ -59,7 +59,7 @@ void alg_reverse(const pkt_proc_alg_ctx *ctx) {
 
 static
 void alg_xor_obfuscate_in(const pkt_proc_alg_ctx *ctx) {
-    assert(ctx->mask && ctx->mask_len);
+    pp_assert(ctx->mask && ctx->mask_len);
     alg_plain(ctx);
     obf_xor_obfuscate(ctx->dst + ctx->dst_offset,
                       ctx->src_len,
@@ -69,7 +69,7 @@ void alg_xor_obfuscate_in(const pkt_proc_alg_ctx *ctx) {
 
 static
 void alg_xor_obfuscate_out(const pkt_proc_alg_ctx *ctx) {
-    assert(ctx->mask && ctx->mask_len);
+    pp_assert(ctx->mask && ctx->mask_len);
     alg_plain(ctx);
     obf_xor_obfuscate(ctx->dst + ctx->dst_offset,
                       ctx->src_len,

--- a/Sources/OpenVPN/OpenVPN_C/pkt_proc.c
+++ b/Sources/OpenVPN/OpenVPN_C/pkt_proc.c
@@ -23,7 +23,6 @@
 //  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include "crypto/allocation.h"

--- a/Sources/OpenVPN/OpenVPN_C/test/crypto_mock.c
+++ b/Sources/OpenVPN/OpenVPN_C/test/crypto_mock.c
@@ -70,11 +70,11 @@ size_t mock_decrypt(void *vctx,
     (void)error;
     DP_LOG("crypto_mock_decrypt");
     size_t out_len = in_len - 4;
-    assert(in[0] == 0xaa);
-    assert(in[1] == 0xbb);
+    pp_assert(in[0] == 0xaa);
+    pp_assert(in[1] == 0xbb);
     reverse(out, in + 2, out_len);
-    assert(in[2 + out_len] == 0xcc);
-    assert(in[2 + out_len + 1] == 0xdd);
+    pp_assert(in[2 + out_len] == 0xcc);
+    pp_assert(in[2 + out_len + 1] == 0xdd);
     return out_len;
 }
 

--- a/Sources/OpenVPN/OpenVPN_C/test/crypto_mock.c
+++ b/Sources/OpenVPN/OpenVPN_C/test/crypto_mock.c
@@ -23,7 +23,6 @@
 //  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
 #include "crypto/allocation.h"
 #include "openvpn/dp_macros.h"
 #include "openvpn/test/crypto_mock.h"

--- a/Sources/OpenVPN/OpenVPN_Cross/Internal/CDataPath.swift
+++ b/Sources/OpenVPN/OpenVPN_Cross/Internal/CDataPath.swift
@@ -369,7 +369,7 @@ extension CDataPath {
             return Data(bytes: buf.pointee.bytes, count: outLength)
         }
         // this should never ever fail because of Swift compile checks
-        assert(decryptedOriginal == decrypted)//, "Parsing is done in-place, work on a copy of decrypted")
+        assert(decryptedOriginal == decrypted, "Parsing is done in-place, work on a copy of decrypted")
         return parsed
     }
 }

--- a/Sources/OpenVPN/OpenVPN_Cross/Internal/CDataPath.swift
+++ b/Sources/OpenVPN/OpenVPN_Cross/Internal/CDataPath.swift
@@ -369,7 +369,7 @@ extension CDataPath {
             return Data(bytes: buf.pointee.bytes, count: outLength)
         }
         // this should never ever fail because of Swift compile checks
-        assert(decryptedOriginal == decrypted, "Parsing is done in-place, work on a copy of decrypted")
+        assert(decryptedOriginal == decrypted)//, "Parsing is done in-place, work on a copy of decrypted")
         return parsed
     }
 }

--- a/Sources/OpenVPN/OpenVPN_Cross/Internal/Constants.swift
+++ b/Sources/OpenVPN/OpenVPN_Cross/Internal/Constants.swift
@@ -34,19 +34,54 @@
 //      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+internal import _PartoutOpenVPN_C
 import Foundation
 import PartoutCore
 
 struct Constants {
+    enum Keys {
+        static let label1 = "OpenVPN master secret"
 
-    // MARK: Session
+        static let label2 = "OpenVPN key expansion"
 
-    static let usesReplayProtection = true
+        static let randomLength = 32
 
-    static let maxPacketSize = 1000
+        static let preMasterLength = 48
 
-    // MARK: Authentication
+        static let keyLength = 64
 
+        static let keysCount = 4
+    }
+
+    enum ControlChannel {
+        static let maxPacketSize = 1000
+
+        // UInt32(0) + UInt8(KeyMethod = 2)
+        static let tlsPrefix = Data(hex: "0000000002")
+
+        private static let numberOfKeys = UInt8(8) // 3-bit
+
+        static func nextKey(after currentKey: UInt8) -> UInt8 {
+            max(1, (currentKey + 1) % numberOfKeys)
+        }
+
+        static let ctrTagLength = 32
+
+        static let ctrPayloadLength = PacketOpcodeLength + PacketSessionIdLength + PacketReplayIdLength + PacketReplayTimestampLength
+    }
+
+    enum DataChannel {
+        static let prngSeedLength = 64
+
+        static let aeadTagLength = 16
+
+        static let aeadIdLength = PacketIdLength
+
+        static let pingString = Data(hex: "2a187bf3641eb4cb07ed2d0a981fc748")
+    }
+}
+
+extension Constants.ControlChannel {
     static func peerInfo(sslVersion: String? = nil, withPlatform: Bool = true, extra: [String: String]? = nil) -> String {
         let uiVersion = Partout.versionIdentifier
         var info = [
@@ -83,31 +118,4 @@ struct Constants {
         info.append("")
         return info.joined(separator: "\n")
     }
-
-    static let randomLength = 32
-
-    // MARK: Keys
-
-    static let label1 = "OpenVPN master secret"
-
-    static let label2 = "OpenVPN key expansion"
-
-    static let preMasterLength = 48
-
-    static let keyLength = 64
-
-    static let keysCount = 4
-
-    // MARK: Protocol
-
-    // UInt32(0) + UInt8(KeyMethod = 2)
-    static let tlsPrefix = Data(hex: "0000000002")
-
-    private static let numberOfKeys = UInt8(8) // 3-bit
-
-    static func nextKey(after currentKey: UInt8) -> UInt8 {
-        max(1, (currentKey + 1) % numberOfKeys)
-    }
-
-    static let pingString = Data(hex: "2a187bf3641eb4cb07ed2d0a981fc748")
 }

--- a/Sources/OpenVPN/OpenVPN_Cross/Internal/ControlChannelSerializer+Crypt.swift
+++ b/Sources/OpenVPN/OpenVPN_Cross/Internal/ControlChannelSerializer+Crypt.swift
@@ -29,10 +29,6 @@ internal import _PartoutOpenVPN_C
 import Foundation
 import PartoutCore
 
-private let CryptoCTRTagLength = 32
-
-private let CryptoCTRPayloadLength = PacketOpcodeLength + PacketSessionIdLength + PacketReplayIdLength + PacketReplayTimestampLength
-
 extension ControlChannel {
     final class CryptSerializer: ControlChannelSerializer {
         private let ctx: PartoutLoggerContext
@@ -70,8 +66,8 @@ extension ControlChannel {
                     crypto_ctr_create(
                         "AES-256-CTR",
                         "SHA256",
-                        CryptoCTRTagLength,
-                        CryptoCTRPayloadLength,
+                        Constants.ControlChannel.ctrTagLength,
+                        Constants.ControlChannel.ctrPayloadLength,
                         $0
                     )
                 }

--- a/Sources/OpenVPN/OpenVPN_Cross/Internal/CryptoKeys+PRF.swift
+++ b/Sources/OpenVPN/OpenVPN_Cross/Internal/CryptoKeys+PRF.swift
@@ -39,28 +39,28 @@ extension CryptoKeys {
 
     init(withPRF prf: PRF) throws {
         let masterData = try Self.prfData(with: PRFInput(
-            label: Constants.label1,
+            label: Constants.Keys.label1,
             secret: CZ(prf.handshake.preMaster),
             clientSeed: CZ(prf.handshake.random1),
             serverSeed: CZ(prf.handshake.serverRandom1),
             clientSessionId: nil,
             serverSessionId: nil,
-            size: Constants.preMasterLength
+            size: Constants.Keys.preMasterLength
         ))
         let keysData = try Self.prfData(with: PRFInput(
-            label: Constants.label2,
+            label: Constants.Keys.label2,
             secret: masterData,
             clientSeed: CZ(prf.handshake.random2),
             serverSeed: CZ(prf.handshake.serverRandom2),
             clientSessionId: prf.sessionId,
             serverSessionId: prf.remoteSessionId,
-            size: Constants.keysCount * Constants.keyLength
+            size: Constants.Keys.keysCount * Constants.Keys.keyLength
         ))
-        assert(keysData.count == Constants.keysCount * Constants.keyLength)
+        assert(keysData.count == Constants.Keys.keysCount * Constants.Keys.keyLength)
 
-        let keysArray = (0..<Constants.keysCount).map {
-            let offset = $0 * Constants.keyLength
-            return keysData.withOffset(offset, length: Constants.keyLength)
+        let keysArray = (0..<Constants.Keys.keysCount).map {
+            let offset = $0 * Constants.Keys.keyLength
+            return keysData.withOffset(offset, length: Constants.Keys.keyLength)
         }
         self.init(
             cipher: CryptoKeys.KeyPair(

--- a/Sources/OpenVPN/OpenVPN_Cross/Internal/Legacy/DataPathWrapper+Legacy.swift
+++ b/Sources/OpenVPN/OpenVPN_Cross/Internal/Legacy/DataPathWrapper+Legacy.swift
@@ -27,10 +27,6 @@ import _PartoutOpenVPNCore
 internal import _PartoutOpenVPNOpenSSL_ObjC
 import PartoutCore
 
-private let PRNGSeedLength = 64
-
-private let DataPathMaxPackets = 100
-
 extension DataPathWrapper {
     static func legacy(
         with parameters: Parameters,
@@ -70,7 +66,7 @@ extension DataPathWrapper {
             peerId: parameters.peerId ?? PacketPeerIdDisabled,
             compressionFraming: compressionFraming.legacyNative,
             compressionAlgorithm: .disabled,
-            maxPackets: DataPathMaxPackets,
+            maxPackets: 100,
             usesReplayProtection: Constants.usesReplayProtection
         )
         return DataPathWrapper(dataPath: dataPath)

--- a/Sources/OpenVPN/OpenVPN_Cross/Internal/Native/DataPathWrapper+Native.swift
+++ b/Sources/OpenVPN/OpenVPN_Cross/Internal/Native/DataPathWrapper+Native.swift
@@ -29,15 +29,9 @@ internal import _PartoutOpenVPN_C
 import Foundation
 import PartoutCore
 
-private let PRNGSeedLength = 64
-
-private let CryptoAEADTagLength = 16
-
-private let CryptoAEADIdLength = PacketIdLength
-
 extension DataPathWrapper {
     static func native(with parameters: Parameters, prf: CryptoKeys.PRF, prng: PRNGProtocol) throws -> DataPathWrapper {
-        let seed = prng.data(length: PRNGSeedLength)
+        let seed = prng.data(length: Constants.DataChannel.prngSeedLength)
         return try .native(with: parameters, prf: prf, seed: CZ(seed))
     }
 
@@ -60,8 +54,8 @@ extension DataPathWrapper {
                 cipherAlgorithm.withCString { cCipher in
                     dp_mode_ad_create_aead(
                         cCipher,
-                        CryptoAEADTagLength,
-                        CryptoAEADIdLength,
+                        Constants.DataChannel.aeadTagLength,
+                        Constants.DataChannel.aeadIdLength,
                         keys,
                         parameters.compressionFraming.cNative
                     )

--- a/Sources/OpenVPN/OpenVPN_Cross/Internal/Negotiator.swift
+++ b/Sources/OpenVPN/OpenVPN_Cross/Internal/Negotiator.swift
@@ -150,7 +150,7 @@ final class Negotiator {
             pp_log(ctx, .openvpn, .error, "Negotiator has no history (not connected yet?)")
             return self
         }
-        let newKey = Constants.nextKey(after: key)
+        let newKey = Constants.ControlChannel.nextKey(after: key)
         return Negotiator(
             ctx,
             key: newKey,
@@ -339,7 +339,7 @@ private extension Negotiator {
             withCode: code,
             key: key,
             payload: payload,
-            maxPacketSize: Constants.maxPacketSize
+            maxPacketSize: Constants.ControlChannel.maxPacketSize
         )
         try flushControlQueue()
     }

--- a/Sources/OpenVPN/OpenVPN_Cross/Internal/OpenVPNSession.swift
+++ b/Sources/OpenVPN/OpenVPN_Cross/Internal/OpenVPNSession.swift
@@ -486,7 +486,7 @@ private extension OpenVPNSession {
         if keepAliveInterval != nil {
             pp_log(ctx, .openvpn, .debug, "Send ping")
             sendDataPackets(
-                [Constants.pingString],
+                [Constants.DataChannel.pingString],
                 to: link,
                 dataChannel: currentDataChannel
             )


### PR DESCRIPTION
- Group Constants by domain
- Wrap assertions in a centralized pp_assert()
- Streamline failure of crypto_*_create() methods with a "goto failure" pattern
- Simplify CRYPTO_* macros
- Review the lifetime of short-lived variables
- Rename some cryptic variables