### PR TITLE
OpenVPN/Cross: Reset TLS channel before renegotiation

### DIFF
--- a/Sources/Crypto/Core_C/include/crypto/tls.h
+++ b/Sources/Crypto/Core_C/include/crypto/tls.h
@@ -70,6 +70,7 @@ tls_channel_options *_Nonnull tls_channel_options_create(int sec_level,
 
 void tls_channel_options_free(tls_channel_options *_Nonnull opt);
 
+// "opt" ownership is transferred and released on free
 tls_channel_ctx _Nullable tls_channel_create(const tls_channel_options *_Nonnull opt,
                                             tls_error_code *_Nonnull error);
 void tls_channel_free(tls_channel_ctx _Nonnull tls);

--- a/Sources/Crypto/Core_C/tls_options.c
+++ b/Sources/Crypto/Core_C/tls_options.c
@@ -1,5 +1,5 @@
 //
-//  tls.c
+//  tls_options.c
 //  Partout
 //
 //  Created by Davide De Rosa on 7/3/25.

--- a/Sources/Crypto/OpenSSL_C/tls.c
+++ b/Sources/Crypto/OpenSSL_C/tls.c
@@ -123,6 +123,8 @@ tls_channel_ctx tls_channel_create(const tls_channel_options *opt, tls_error_cod
         }
     }
 
+    // no longer fails
+
     tls_channel_ctx tls = pp_alloc_crypto(sizeof(tls_channel_t));
     tls->opt = opt;
     tls->buf_len = tls->opt->buf_len;

--- a/Sources/Crypto/OpenSSL_C/tls.c
+++ b/Sources/Crypto/OpenSSL_C/tls.c
@@ -39,16 +39,16 @@ static int tls_channel_ex_data_idx = -1;
 
 struct tls_channel_t {
     const tls_channel_options *_Nonnull opt;
-    bool is_connected;
     SSL_CTX *_Nonnull ssl_ctx;
+    size_t buf_len;
+    uint8_t *_Nonnull buf_cipher;
+    uint8_t *_Nonnull buf_plain;
 
     SSL *_Nonnull ssl;
     BIO *_Nonnull bio_plain;
     BIO *_Nonnull bio_cipher_in;
     BIO *_Nonnull bio_cipher_out;
-    uint8_t *_Nonnull buf_cipher;
-    uint8_t *_Nonnull buf_plain;
-    size_t buf_len;
+    bool is_connected;
 };
 
 static
@@ -127,8 +127,8 @@ tls_channel_ctx tls_channel_create(const tls_channel_options *opt, tls_error_cod
 
     tls_channel_ctx tls = pp_alloc_crypto(sizeof(tls_channel_t));
     tls->opt = opt;
-    tls->buf_len = tls->opt->buf_len;
     tls->ssl_ctx = ssl_ctx;
+    tls->buf_len = tls->opt->buf_len;
     tls->buf_cipher = pp_alloc_crypto(tls->buf_len);
     tls->buf_plain = pp_alloc_crypto(tls->buf_len);
     return tls;
@@ -161,8 +161,8 @@ void tls_channel_free(tls_channel_ctx tls) {
     }
 
     pp_zero(tls->buf_cipher, tls->opt->buf_len);
-    free(tls->buf_cipher);
     pp_zero(tls->buf_plain, tls->opt->buf_len);
+    free(tls->buf_cipher);
     free(tls->buf_plain);
     tls_channel_options_free((tls_channel_options *)tls->opt);
     SSL_CTX_free(tls->ssl_ctx);

--- a/Sources/OpenVPN/OpenVPN_C/include/openvpn/dp_mode.h
+++ b/Sources/OpenVPN/OpenVPN_C/include/openvpn/dp_mode.h
@@ -139,6 +139,8 @@ typedef struct {
     dp_mode_parse_ctx parse_ctx;
 } dp_mode_t;
 
+// "crypto" is owned and released on free
+
 dp_mode_t *_Nonnull dp_mode_create_opt(crypto_ctx _Nonnull crypto,
                                        crypto_free_fn _Nonnull crypto_free,
                                        const dp_mode_encrypter_t *_Nonnull enc,

--- a/Sources/OpenVPN/OpenVPN_Cross/Internal/Negotiator.swift
+++ b/Sources/OpenVPN/OpenVPN_Cross/Internal/Negotiator.swift
@@ -410,8 +410,6 @@ private extension Negotiator {
             } catch let cError as CTLSError {
                 pp_log(ctx, .openvpn, .fault, "TLS.connect: Failed pulling ciphertext: \(cError.code)")
                 throw cError
-            } catch {
-                throw error
             }
 
             pp_log(ctx, .openvpn, .info, "TLS.connect: Pulled ciphertext \(cipherTextOut.asSensitiveBytes(ctx))")


### PR DESCRIPTION
And improve the overall control flow of TLS C code.

Fixes #115 