### PR TITLE
API: Fix String escaping in JavaScript arguments

### DIFF
--- a/Sources/APIBundle/JSON/v7/providers/nordvpn.js
+++ b/Sources/APIBundle/JSON/v7/providers/nordvpn.js
@@ -25,7 +25,7 @@
 function getInfrastructure(headers, preferCache) {
     const providerId = "nordvpn";
     if (preferCache) {
-        const json = api.getJSON("https://passepartoutvpn.app/api-cache/v6/providers/nordvpn/fetch.json", headers);
+        const json = api.getJSON("https://passepartoutvpn.app/api-cache/v7/providers/nordvpn/fetch.json", headers);
         if (json && json.response) {
             json.response.cache = json.cache;
         }

--- a/Sources/Partout/API/DefaultAPIMapper.swift
+++ b/Sources/Partout/API/DefaultAPIMapper.swift
@@ -116,7 +116,7 @@ extension ScriptingEngine {
             throw PartoutError(.encoding)
         }
         let result = try await execute(
-            "JSON.stringify(authenticate(JSON.parse('\(moduleJSON)'), '\(deviceId)'))",
+            "JSON.stringify(authenticate(JSON.parse('\(moduleJSON.jsEscaped)'), '\(deviceId)'))",
             after: script,
             returning: ScriptResult<ProviderModule>.self
         )
@@ -142,8 +142,9 @@ extension ScriptingEngine {
             throw PartoutError(.encoding)
         }
         pp_log(ctx, .api, .debug, "Headers: \(headersJSON)")
+        pp_log(ctx, .api, .debug, "Headers (escaped): \(headersJSON.jsEscaped)")
         let result = try await execute(
-            "JSON.stringify(getInfrastructure(JSON.parse('\(headersJSON)')))",
+            "JSON.stringify(getInfrastructure(JSON.parse('\(headersJSON.jsEscaped)')))",
             after: script,
             returning: ScriptResult<ProviderInfrastructure>.self
         )
@@ -161,6 +162,14 @@ extension ScriptingEngine {
 }
 
 // MARK: - Helpers
+
+private extension String {
+    var jsEscaped: String {
+        replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}
 
 private extension DefaultAPIMapper {
     func script(for resource: API.REST.Resource) async throws -> String {


### PR DESCRIPTION
Some complex strings may fail to parse in JSON.parse() because of non-escaped backslash sequences.