### PR TITLE
API: Fetch infrastructures with whole ProviderModule

### DIFF
--- a/API/lib/context.js
+++ b/API/lib/context.js
@@ -126,9 +126,10 @@ export function fetchRawInfrastructure(scriptPath, options) {
     };
 
     const preferCache = options.preferCache ?? true;
+    // headers, module, preferCache
     const wrappedScript = `
         ${script}
-        getInfrastructure({}, ${preferCache});
+        getInfrastructure({}, null, ${preferCache});
     `;
     const json = runSandboxedScript(wrappedScript, injectedFunctions);
     if (options.responseOnly) {

--- a/API/lib/context.js
+++ b/API/lib/context.js
@@ -126,7 +126,7 @@ export function fetchRawInfrastructure(scriptPath, options) {
     };
 
     const preferCache = options.preferCache ?? true;
-    // headers, module, preferCache
+    // module, headers, preferCache
     const wrappedScript = `
         ${script}
         getInfrastructure(null, {}, ${preferCache});

--- a/API/lib/context.js
+++ b/API/lib/context.js
@@ -129,7 +129,7 @@ export function fetchRawInfrastructure(scriptPath, options) {
     // headers, module, preferCache
     const wrappedScript = `
         ${script}
-        getInfrastructure({}, null, ${preferCache});
+        getInfrastructure(null, {}, ${preferCache});
     `;
     const json = runSandboxedScript(wrappedScript, injectedFunctions);
     if (options.responseOnly) {

--- a/Sources/API/APIMapper.swift
+++ b/Sources/API/APIMapper.swift
@@ -31,5 +31,5 @@ public protocol APIMapper {
 
     func authenticate(_ module: ProviderModule, on deviceId: String) async throws -> ProviderModule
 
-    func infrastructure(for providerId: ProviderID, cache: ProviderCache?) async throws -> ProviderInfrastructure
+    func infrastructure(for module: ProviderModule, cache: ProviderCache?) async throws -> ProviderInfrastructure
 }

--- a/Sources/APIBundle/JSON/v7/providers/hideme.js
+++ b/Sources/APIBundle/JSON/v7/providers/hideme.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers) {
+function getInfrastructure(headers, module) {
     const providerId = "hideme";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/hideme.js
+++ b/Sources/APIBundle/JSON/v7/providers/hideme.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers, module) {
+function getInfrastructure(module, headers) {
     const providerId = "hideme";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/ivpn.js
+++ b/Sources/APIBundle/JSON/v7/providers/ivpn.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers) {
+function getInfrastructure(headers, module) {
     const providerId = "ivpn";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/ivpn.js
+++ b/Sources/APIBundle/JSON/v7/providers/ivpn.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers, module) {
+function getInfrastructure(module, headers) {
     const providerId = "ivpn";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/mullvad.js
+++ b/Sources/APIBundle/JSON/v7/providers/mullvad.js
@@ -223,7 +223,7 @@ function authenticate(module, deviceId) {
     };
 }
 
-function getInfrastructure(headers, module) {
+function getInfrastructure(module, headers) {
     const providerId = "mullvad";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/mullvad.js
+++ b/Sources/APIBundle/JSON/v7/providers/mullvad.js
@@ -223,7 +223,7 @@ function authenticate(module, deviceId) {
     };
 }
 
-function getInfrastructure(headers) {
+function getInfrastructure(headers, module) {
     const providerId = "mullvad";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/nordvpn.js
+++ b/Sources/APIBundle/JSON/v7/providers/nordvpn.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers, module, preferCache) {
+function getInfrastructure(module, headers, preferCache) {
     const providerId = "nordvpn";
     if (preferCache) {
         const json = api.getJSON("https://passepartoutvpn.app/api-cache/v7/providers/nordvpn/fetch.json", headers);

--- a/Sources/APIBundle/JSON/v7/providers/nordvpn.js
+++ b/Sources/APIBundle/JSON/v7/providers/nordvpn.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers, preferCache) {
+function getInfrastructure(headers, module, preferCache) {
     const providerId = "nordvpn";
     if (preferCache) {
         const json = api.getJSON("https://passepartoutvpn.app/api-cache/v7/providers/nordvpn/fetch.json", headers);

--- a/Sources/APIBundle/JSON/v7/providers/oeck.js
+++ b/Sources/APIBundle/JSON/v7/providers/oeck.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers) {
+function getInfrastructure(headers, module) {
     const providerId = "oeck";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/oeck.js
+++ b/Sources/APIBundle/JSON/v7/providers/oeck.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers, module) {
+function getInfrastructure(module, headers) {
     const providerId = "oeck";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/pia.js
+++ b/Sources/APIBundle/JSON/v7/providers/pia.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers) {
+function getInfrastructure(headers, module) {
     const providerId = "pia";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/pia.js
+++ b/Sources/APIBundle/JSON/v7/providers/pia.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers, module) {
+function getInfrastructure(module, headers) {
     const providerId = "pia";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/surfshark.js
+++ b/Sources/APIBundle/JSON/v7/providers/surfshark.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers, module) {
+function getInfrastructure(module, headers) {
     const providerId = "surfshark";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/surfshark.js
+++ b/Sources/APIBundle/JSON/v7/providers/surfshark.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers) {
+function getInfrastructure(headers, module) {
     const providerId = "surfshark";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/torguard.js
+++ b/Sources/APIBundle/JSON/v7/providers/torguard.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers, module) {
+function getInfrastructure(module, headers) {
     const providerId = "torguard";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/torguard.js
+++ b/Sources/APIBundle/JSON/v7/providers/torguard.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers) {
+function getInfrastructure(headers, module) {
     const providerId = "torguard";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/tunnelbear.js
+++ b/Sources/APIBundle/JSON/v7/providers/tunnelbear.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers, module) {
+function getInfrastructure(module, headers) {
     const providerId = "tunnelbear";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/tunnelbear.js
+++ b/Sources/APIBundle/JSON/v7/providers/tunnelbear.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers) {
+function getInfrastructure(headers, module) {
     const providerId = "tunnelbear";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/vyprvpn.js
+++ b/Sources/APIBundle/JSON/v7/providers/vyprvpn.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers) {
+function getInfrastructure(headers, module) {
     const providerId = "vyprvpn";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/vyprvpn.js
+++ b/Sources/APIBundle/JSON/v7/providers/vyprvpn.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers, module) {
+function getInfrastructure(module, headers) {
     const providerId = "vyprvpn";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/windscribe.js
+++ b/Sources/APIBundle/JSON/v7/providers/windscribe.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers) {
+function getInfrastructure(headers, module) {
     const providerId = "windscribe";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/APIBundle/JSON/v7/providers/windscribe.js
+++ b/Sources/APIBundle/JSON/v7/providers/windscribe.js
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-function getInfrastructure(headers, module) {
+function getInfrastructure(module, headers) {
     const providerId = "windscribe";
     const openVPN = {
         moduleType: "OpenVPN",

--- a/Sources/Partout/API/DefaultAPIMapper.swift
+++ b/Sources/Partout/API/DefaultAPIMapper.swift
@@ -105,7 +105,10 @@ public final class DefaultAPIMapper: APIMapper {
 // TODO: #54/partout, assumes engine to be JavaScript
 extension ScriptingEngine {
     func authenticate(_ ctx: PartoutLoggerContext, _ module: ProviderModule, on deviceId: String, with library: String) async throws -> ProviderModule {
-        let script = try scriptCall(ctx, withName: "authenticate", args: [module, deviceId])
+        let script = try scriptCall(ctx, withName: "authenticate", args: [
+            module.stripped(),
+            deviceId
+        ])
         let result = try await execute(
             script,
             after: library,
@@ -128,7 +131,11 @@ extension ScriptingEngine {
         if let tag = cache?.tag {
             headers["If-None-Match"] = tag
         }
-        let script = try scriptCall(ctx, withName: "getInfrastructure", args: [module, headers, true])
+        let script = try scriptCall(ctx, withName: "getInfrastructure", args: [
+            module.stripped(),
+            headers,
+            true
+        ])
         let result = try await execute(
             script,
             after: library,
@@ -175,6 +182,16 @@ extension ScriptingEngine {
 }
 
 // MARK: - Helpers
+
+private extension ProviderModule {
+
+    // save heavy encoding of unused .entity
+    func stripped() throws -> Self {
+        var stripped = builder()
+        stripped.entity = nil
+        return try stripped.tryBuild()
+    }
+}
 
 private extension String {
     var jsEscaped: String {

--- a/Sources/Partout/API/DefaultAPIMapper.swift
+++ b/Sources/Partout/API/DefaultAPIMapper.swift
@@ -128,7 +128,7 @@ extension ScriptingEngine {
         if let tag = cache?.tag {
             headers["If-None-Match"] = tag
         }
-        let script = try scriptCall(ctx, withName: "getInfrastructure", args: [headers, module])
+        let script = try scriptCall(ctx, withName: "getInfrastructure", args: [module, headers, true])
         let result = try await execute(
             script,
             after: library,
@@ -152,6 +152,8 @@ extension ScriptingEngine {
                 if let value = $0 as? String {
                     return "'\(value)'"
                 } else if let value = $0 as? Int {
+                    return value.description
+                } else if let value = $0 as? Bool {
                     return value.description
                 } else if let value = $0 as? Encodable {
                     let encoded = try JSONEncoder().encode(value)

--- a/Sources/Partout/Providers/ProviderScriptingEngine+Apple.swift
+++ b/Sources/Partout/Providers/ProviderScriptingEngine+Apple.swift
@@ -44,7 +44,7 @@ extension AppleJavaScriptEngine: ProviderScriptingEngine {
         func errorResponse(_ message: String) -> [String: Any]
         func httpErrorResponse(_ status: Int, _ urlString: String) -> [String: Any]
         func debug(_ message: String)
-        func version() -> Int
+        func version() -> String
     }
 
     //
@@ -118,7 +118,7 @@ extension AppleJavaScriptEngine: ProviderScriptingEngine {
             vm.debug(message: message)
         }
 
-        func version() -> Int {
+        func version() -> String {
             vm.version
         }
     }

--- a/Sources/Partout/Providers/ProviderScriptingEngine+Apple.swift
+++ b/Sources/Partout/Providers/ProviderScriptingEngine+Apple.swift
@@ -44,6 +44,7 @@ extension AppleJavaScriptEngine: ProviderScriptingEngine {
         func errorResponse(_ message: String) -> [String: Any]
         func httpErrorResponse(_ status: Int, _ urlString: String) -> [String: Any]
         func debug(_ message: String)
+        func version() -> Int
     }
 
     //
@@ -115,6 +116,10 @@ extension AppleJavaScriptEngine: ProviderScriptingEngine {
 
         func debug(_ message: String) {
             vm.debug(message: message)
+        }
+
+        func version() -> Int {
+            vm.version
         }
     }
 

--- a/Sources/Providers/DefaultProviderScriptingAPI.swift
+++ b/Sources/Providers/DefaultProviderScriptingAPI.swift
@@ -57,8 +57,8 @@ public final class DefaultProviderScriptingAPI {
 }
 
 extension DefaultProviderScriptingAPI: ProviderScriptingAPI {
-    public var version: Int {
-        2
+    public var version: String {
+        "20250718"
     }
 
     public func getResult(

--- a/Sources/Providers/DefaultProviderScriptingAPI.swift
+++ b/Sources/Providers/DefaultProviderScriptingAPI.swift
@@ -57,6 +57,10 @@ public final class DefaultProviderScriptingAPI {
 }
 
 extension DefaultProviderScriptingAPI: ProviderScriptingAPI {
+    public var version: Int {
+        2
+    }
+
     public func getResult(
         method: String,
         urlString: String,

--- a/Sources/Providers/ProviderModule.swift
+++ b/Sources/Providers/ProviderModule.swift
@@ -243,6 +243,10 @@ extension ProviderModule {
 
 extension ProviderModule {
     public init(emptyWithProviderId providerId: ProviderID) throws {
-        self = try Builder(providerId: providerId).tryBuild()
+
+        // requires the two for .tryBuild() to succeed
+        let moduleType = ModuleType("")
+        self = try Builder(providerId: providerId, providerModuleType: moduleType)
+            .tryBuild()
     }
 }

--- a/Sources/Providers/ProviderModule.swift
+++ b/Sources/Providers/ProviderModule.swift
@@ -238,3 +238,11 @@ extension ProviderModule {
         }
     }
 }
+
+// MARK: - Shortcuts
+
+extension ProviderModule {
+    public init(emptyWithProviderId providerId: ProviderID) throws {
+        self = try Builder(providerId: providerId).tryBuild()
+    }
+}

--- a/Sources/Providers/ProviderScriptingAPI.swift
+++ b/Sources/Providers/ProviderScriptingAPI.swift
@@ -24,6 +24,8 @@
 //
 
 public protocol ProviderScriptingAPI {
+    var version: Int { get }
+
     func getResult(
         method: String,
         urlString: String,

--- a/Sources/Providers/ProviderScriptingAPI.swift
+++ b/Sources/Providers/ProviderScriptingAPI.swift
@@ -24,7 +24,7 @@
 //
 
 public protocol ProviderScriptingAPI {
-    var version: Int { get }
+    var version: String { get }
 
     func getResult(
         method: String,

--- a/Tests/API/Mock.swift
+++ b/Tests/API/Mock.swift
@@ -57,7 +57,7 @@ struct MockAPI: APIMapper {
         module
     }
 
-    func infrastructure(for providerId: ProviderID, cache: ProviderCache?) async throws -> ProviderInfrastructure {
+    func infrastructure(for module: ProviderModule, cache: ProviderCache?) async throws -> ProviderInfrastructure {
         ProviderInfrastructure(
             presets: [
                 ProviderPreset(

--- a/Tests/API/ProviderManagerTests.swift
+++ b/Tests/API/ProviderManagerTests.swift
@@ -108,7 +108,8 @@ private extension ProviderManagerTests {
             let repository = MockRepository()
 
             let providerManager = APIManager(.global, from: [api], repository: repository)
-            try await providerManager.fetchInfrastructure(for: .mock)
+            let module = try ProviderModule(emptyWithProviderId: .mock)
+            try await providerManager.fetchInfrastructure(for: module)
 
             return repository.providerRepository(for: providerId)
         } catch {

--- a/Tests/Partout/API/APITestSuite.swift
+++ b/Tests/Partout/API/APITestSuite.swift
@@ -60,7 +60,8 @@ extension APITestSuite {
         let sut = try newAPIMapper()
         let begin = Date()
         for _ in 0..<1000 {
-            _ = try await sut.infrastructure(for: .hideme, cache: nil)
+            let module = try ProviderModule(emptyWithProviderId: .hideme)
+            _ = try await sut.infrastructure(for: module, cache: nil)
         }
         print("Elapsed: \(-begin.timeIntervalSinceNow)")
     }

--- a/Tests/Partout/API/HideMeProviderTests.swift
+++ b/Tests/Partout/API/HideMeProviderTests.swift
@@ -58,7 +58,8 @@ struct HideMeProviderTests: APITestSuite {
             hijacker(forFetchURL: $1)
         } : nil)
         do {
-            let infra = try await sut.infrastructure(for: .hideme, cache: input.cache)
+            let module = try ProviderModule(emptyWithProviderId: .hideme)
+            let infra = try await sut.infrastructure(for: module, cache: input.cache)
             #expect(infra.presets.count == input.presetsCount)
             #expect(infra.servers.count == input.serversCount)
 

--- a/Tests/Partout/ProviderScriptingEngineTests.swift
+++ b/Tests/Partout/ProviderScriptingEngineTests.swift
@@ -33,8 +33,8 @@ struct ProviderScriptingEngineTests {
         let api = DefaultProviderScriptingAPI(.global, timeout: 3.0)
         let sut = api.newScriptingEngine(.global)
 
-        let version = try await sut.execute("JSON.stringify(api.version())", after: nil, returning: Int.self)
-        #expect(version == 2)
+        let version = try await sut.execute("JSON.stringify(api.version())", after: nil, returning: String.self)
+        #expect(version == "20250718")
 
         let base64 = try await sut.execute("JSON.stringify(api.jsonToBase64({\"foo\":\"bar\"}))", after: nil, returning: String.self)
         #expect(base64 == "eyJmb28iOiJiYXIifQ==")

--- a/Tests/Partout/ProviderScriptingEngineTests.swift
+++ b/Tests/Partout/ProviderScriptingEngineTests.swift
@@ -23,7 +23,20 @@
 //  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+@testable import Partout
+import PartoutProviders
 import Testing
 
 struct ProviderScriptingEngineTests {
+    @Test
+    func givenEngine_whenUseAPI_thenWorks() async throws {
+        let api = DefaultProviderScriptingAPI(.global, timeout: 3.0)
+        let sut = api.newScriptingEngine(.global)
+
+        let version = try await sut.execute("JSON.stringify(api.version())", after: nil, returning: Int.self)
+        #expect(version == 2)
+
+        let base64 = try await sut.execute("JSON.stringify(api.jsonToBase64({\"foo\":\"bar\"}))", after: nil, returning: String.self)
+        #expect(base64 == "eyJmb28iOiJiYXIifQ==")
+    }
 }

--- a/Tests/Providers/ProviderScriptingAPITests.swift
+++ b/Tests/Providers/ProviderScriptingAPITests.swift
@@ -28,21 +28,6 @@ import Foundation
 import Testing
 
 struct ProviderScriptingAPITests {
-
-    @Test
-    func givenScriptResult_whenHasCache_thenReturnsProviderCache() throws {
-        let date = Timestamp.now()
-        let tag = "12345"
-        let sut = ProviderScriptResult("", status: nil, lastModified: date, tag: tag)
-
-        let object = try #require(sut.serialized()["cache"])
-        let data = try JSONSerialization.data(withJSONObject: object)
-        let cache = try JSONDecoder().decode(ProviderCache.self, from: data)
-
-        #expect(cache.lastUpdate == date)
-        #expect(cache.tag == tag)
-    }
-
     @Test
     func givenAPI_whenProviderGetResult_thenIsMapped() {
         let sut = DefaultProviderScriptingAPI(.global, timeout: 3.0) {
@@ -67,5 +52,19 @@ struct ProviderScriptingAPITests {
     func givenTimestamp_whenGetRFC1123_thenIsExpected(timestamp: Timestamp, rfc: String) {
         #expect(timestamp.toRFC1123() == rfc)
         #expect(rfc.fromRFC1123() == timestamp)
+    }
+
+    @Test
+    func givenScriptResult_whenHasCache_thenReturnsProviderCache() throws {
+        let date = Timestamp.now()
+        let tag = "12345"
+        let sut = ProviderScriptResult("", status: nil, lastModified: date, tag: tag)
+
+        let object = try #require(sut.serialized()["cache"])
+        let data = try JSONSerialization.data(withJSONObject: object)
+        let cache = try JSONDecoder().decode(ProviderCache.self, from: data)
+
+        #expect(cache.lastUpdate == date)
+        #expect(cache.tag == tag)
     }
 }

--- a/Tests/Providers/ProviderScriptingAPITests.swift
+++ b/Tests/Providers/ProviderScriptingAPITests.swift
@@ -31,7 +31,7 @@ struct ProviderScriptingAPITests {
     @Test
     func givenAPI_whenGetVersion_thenIsExpected() {
         let sut = DefaultProviderScriptingAPI(.global, timeout: 3.0)
-        #expect(sut.version == 2)
+        #expect(sut.version == "20250718")
     }
 
     @Test

--- a/Tests/Providers/ProviderScriptingAPITests.swift
+++ b/Tests/Providers/ProviderScriptingAPITests.swift
@@ -29,6 +29,12 @@ import Testing
 
 struct ProviderScriptingAPITests {
     @Test
+    func givenAPI_whenGetVersion_thenIsExpected() {
+        let sut = DefaultProviderScriptingAPI(.global, timeout: 3.0)
+        #expect(sut.version == 2)
+    }
+
+    @Test
     func givenAPI_whenProviderGetResult_thenIsMapped() {
         let sut = DefaultProviderScriptingAPI(.global, timeout: 3.0) {
             #expect($0 == "GET")


### PR DESCRIPTION
Be prepared for authenticated API calls by passing the whole module to the script, so that it has access to the .authentication and .moduleOptions fields for complex scenarios.

Plus:

- Add the new `api.version()` field, based on the ISO date of the latest API changes
- Pass `preferCache: true` to `getInfrastructure()`
- Improve how the JS call is built (convoluted stringify/parse)