### PR TITLE
NE: Restore "leaking" versions of socket observers

### DIFF
--- a/Sources/Vendors/AppleNE/Connection/NETCPSocket.swift
+++ b/Sources/Vendors/AppleNE/Connection/NETCPSocket.swift
@@ -108,6 +108,8 @@ private actor NETCPSocket: LinkInterface {
 // MARK: LinkInterface
 
 extension NETCPSocket {
+
+    // FIXME: #117, #131, stream() might cause a retain cycle on self
     nonisolated var hasBetterPath: AsyncStream<Void> {
         nwConnection
             .publisher(for: \.hasBetterPath)

--- a/Sources/Vendors/AppleNE/Connection/NETCPSocket.swift
+++ b/Sources/Vendors/AppleNE/Connection/NETCPSocket.swift
@@ -109,8 +109,13 @@ private actor NETCPSocket: LinkInterface {
 
 extension NETCPSocket {
     nonisolated var hasBetterPath: AsyncStream<Void> {
-        stream(for: \.hasBetterPath, of: nwConnection) { $0 }
+        nwConnection
+            .publisher(for: \.hasBetterPath)
+            .removeDuplicates()
+            .filter { $0 } // true
             .map { _ in }
+            .stream()
+            .ignoreErrors()
     }
 
     nonisolated func upgraded() -> LinkInterface {

--- a/Sources/Vendors/AppleNE/Connection/NEUDPSocket.swift
+++ b/Sources/Vendors/AppleNE/Connection/NEUDPSocket.swift
@@ -107,8 +107,13 @@ private actor NEUDPSocket: LinkInterface {
 
 extension NEUDPSocket {
     nonisolated var hasBetterPath: AsyncStream<Void> {
-        stream(for: \.hasBetterPath, of: nwSession) { $0 }
+        nwSession
+            .publisher(for: \.hasBetterPath)
+            .removeDuplicates()
+            .filter { $0 } // true
             .map { _ in }
+            .stream()
+            .ignoreErrors()
     }
 
     nonisolated func upgraded() -> LinkInterface {

--- a/Sources/Vendors/AppleNE/Connection/NEUDPSocket.swift
+++ b/Sources/Vendors/AppleNE/Connection/NEUDPSocket.swift
@@ -106,6 +106,8 @@ private actor NEUDPSocket: LinkInterface {
 // MARK: LinkInterface
 
 extension NEUDPSocket {
+
+    // FIXME: #117, #131, stream() might cause a retain cycle on self
     nonisolated var hasBetterPath: AsyncStream<Void> {
         nwSession
             .publisher(for: \.hasBetterPath)


### PR DESCRIPTION
Part of #117 may have caused a regression in Passepartout 3.5.4 in the UDP/TCP observers of hasBetterPath. This is a blind attempt to shed some light, revert the "fix" and retry again later.