### PR TITLE
NE: Expose impl-specific module requirements

### DIFF
--- a/Sources/Vendors/AppleNE/Extensions/Module+Requirements.swift
+++ b/Sources/Vendors/AppleNE/Extensions/Module+Requirements.swift
@@ -1,0 +1,32 @@
+//
+//  Module+Requirements.swift
+//  Partout
+//
+//  Created by Davide De Rosa on 7/20/25.
+//  Copyright (c) 2025 Davide De Rosa. All rights reserved.
+//
+//  https://github.com/passepartoutvpn
+//
+//  This file is part of Partout.
+//
+//  Partout is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Partout is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Partout.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import PartoutCore
+
+extension Module {
+    public var requiresConnection: Bool {
+        [.httpProxy, .ip].contains(moduleHandler.id)
+    }
+}


### PR DESCRIPTION
Network Extension requires a VPN connection for routing and HTTP proxies to work. Other platforms may have different requirements. Start providing this information.

Related to https://github.com/passepartoutvpn/passepartout/issues/1441