### PR TITLE
WireGuard: Require non-empty peers

### DIFF
--- a/Sources/WireGuard/Core/Partout+WireGuard.swift
+++ b/Sources/WireGuard/Core/Partout+WireGuard.swift
@@ -9,6 +9,7 @@ extension LoggerCategory {
 }
 
 extension PartoutError.Code {
-    enum WireGuard {
+    public enum WireGuard {
+        public static let emptyPeers = PartoutError.Code("WireGuard.emptyPeers")
     }
 }

--- a/Sources/WireGuard/Core/WireGuard+Configuration.swift
+++ b/Sources/WireGuard/Core/WireGuard+Configuration.swift
@@ -52,6 +52,9 @@ extension WireGuard.Configuration {
         }
 
         public func tryBuild() throws -> WireGuard.Configuration {
+            guard !peers.isEmpty else {
+                throw PartoutError(.WireGuard.emptyPeers)
+            }
             return WireGuard.Configuration(
                 interface: try interface.tryBuild(),
                 peers: try peers.map {

--- a/Sources/WireGuard/Core/WireGuardModule.swift
+++ b/Sources/WireGuard/Core/WireGuardModule.swift
@@ -49,12 +49,15 @@ extension WireGuardModule {
         }
 
         public func tryBuild() throws -> WireGuardModule {
-            guard configurationBuilder != nil else {
+            guard let configurationBuilder else {
                 throw PartoutError(.incompleteModule, self)
+            }
+            guard !configurationBuilder.peers.isEmpty else {
+                throw PartoutError(.WireGuard.emptyPeers)
             }
             return WireGuardModule(
                 id: id,
-                configuration: try configurationBuilder?.tryBuild()
+                configuration: try configurationBuilder.tryBuild()
             )
         }
     }

--- a/Sources/WireGuard/Core/WireGuardModule.swift
+++ b/Sources/WireGuard/Core/WireGuardModule.swift
@@ -52,9 +52,6 @@ extension WireGuardModule {
             guard let configurationBuilder else {
                 throw PartoutError(.incompleteModule, self)
             }
-            guard !configurationBuilder.peers.isEmpty else {
-                throw PartoutError(.WireGuard.emptyPeers)
-            }
             return WireGuardModule(
                 id: id,
                 configuration: try configurationBuilder.tryBuild()

--- a/Tests/Partout/RegistryTests.swift
+++ b/Tests/Partout/RegistryTests.swift
@@ -27,7 +27,8 @@ final class RegistryTests: XCTestCase {
             try XCTUnwrap(.init("host.name", .init(.tcp, 80)))
         ]
 
-        let wgBuilder = WireGuard.Configuration.Builder(privateKey: "")
+        var wgBuilder = WireGuard.Configuration.Builder(privateKey: "")
+        wgBuilder.peers = [.init(publicKey: "")]
 
         var profileBuilder = Profile.Builder()
         profileBuilder.modules.append(try DNSModule.Builder().tryBuild())

--- a/Tests/WireGuard/Core/Dummy.swift
+++ b/Tests/WireGuard/Core/Dummy.swift
@@ -1,5 +1,0 @@
-// SPDX-FileCopyrightText: 2025 Davide De Rosa
-//
-// SPDX-License-Identifier: GPL-3.0
-
-import Foundation

--- a/Tests/WireGuard/Core/ModuleTests.swift
+++ b/Tests/WireGuard/Core/ModuleTests.swift
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+import PartoutCore
+import PartoutWireGuard
+import Testing
+
+struct ModuleTests {
+    @Test
+    func givenBuilder_whenEmptyPeers_thenFails() throws {
+        let pvtkey = "SMy9zR0KUgqYqZ0pcyL3sJmJkmNkU8PA5mnr9nh3zUs="
+        let pubkey = "BJgXqaX9zQbZwBcvWMaYpxzXhIAmKxT4P7d9gklYxhw="
+
+        var sut = WireGuardModule.Builder()
+        sut.configurationBuilder = WireGuard.Configuration.Builder(privateKey: pvtkey)
+        #expect(throws: PartoutError.self, performing: { try sut.tryBuild() })
+
+        sut.configurationBuilder?.peers = [.init(publicKey: pubkey)]
+        let module = try sut.tryBuild()
+
+        #expect(module.configuration?.interface.privateKey.rawValue == pvtkey)
+        #expect(module.configuration?.peers.first?.publicKey.rawValue == pubkey)
+    }
+}


### PR DESCRIPTION
Avoid situations where WireGuard seems active but is actually doing nothing.