### PR TITLE
NE: Implement NWConnection-based socket observer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,8 +41,8 @@ let cSettings: [CSetting] = [
 let package = Package(
     name: "partout",
     platforms: [
-        .iOS(.v16),
-        .macOS(.v13),
+        .iOS(.v15),
+        .macOS(.v12),
         .tvOS(.v17)
     ],
     products: [

--- a/Package.swift
+++ b/Package.swift
@@ -41,8 +41,8 @@ let cSettings: [CSetting] = [
 let package = Package(
     name: "partout",
     platforms: [
-        .iOS(.v15),
-        .macOS(.v12),
+        .iOS(.v16),
+        .macOS(.v13),
         .tvOS(.v17)
     ],
     products: [

--- a/Sources/Vendors/AppleNE/Connection/NEInterfaceFactory.swift
+++ b/Sources/Vendors/AppleNE/Connection/NEInterfaceFactory.swift
@@ -10,7 +10,7 @@ import PartoutCore
 public final class NEInterfaceFactory: NetworkInterfaceFactory {
     public struct Options: Sendable {
         // Enable to use NWConnection, NW* sockets were removed from NetworkExtension.
-        public var withNetworkFramework = false
+        public var usesNetworkFramework = false
 
         public var maxUDPDatagrams = 200
 
@@ -42,7 +42,7 @@ public final class NEInterfaceFactory: NetworkInterfaceFactory {
         }
         switch endpoint.proto.socketType.plainType {
         case .udp:
-            if options.withNetworkFramework {
+            if options.usesNetworkFramework {
                 let impl = NWConnection(to: endpoint.nwEndpoint, using: .udp)
                 let socketOptions = NESocketObserver.Options(
                     proto: .udp,
@@ -65,7 +65,7 @@ public final class NEInterfaceFactory: NetworkInterfaceFactory {
             }
 
         case .tcp:
-            if options.withNetworkFramework {
+            if options.usesNetworkFramework {
                 let impl = NWConnection(to: endpoint.nwEndpoint, using: .tcp)
                 let socketOptions = NESocketObserver.Options(
                     proto: .tcp,

--- a/Sources/Vendors/AppleNE/Connection/NEInterfaceFactory.swift
+++ b/Sources/Vendors/AppleNE/Connection/NEInterfaceFactory.swift
@@ -9,6 +9,9 @@ import PartoutCore
 /// A ``/PartoutCore/NetworkInterfaceFactory`` that spawns ``/PartoutCore/LinkInterface`` and ``/PartoutCore/TunnelInterface`` objects from a `NEPacketTunnelProvider`.
 public final class NEInterfaceFactory: NetworkInterfaceFactory {
     public struct Options: Sendable {
+        // Enable to use NWConnection, NW* sockets were removed from NetworkExtension.
+        public var withNetworkFramework = false
+
         public var maxUDPDatagrams = 200
 
         public var minTCPLength = 2
@@ -37,28 +40,45 @@ public final class NEInterfaceFactory: NetworkInterfaceFactory {
             logReleasedProvider()
             return nil
         }
-        let nwEndpoint = endpoint.nwEndpoint
         switch endpoint.proto.socketType.plainType {
         case .udp:
-            let impl = provider.createUDPSession(to: nwEndpoint, from: nil)
-            return NEUDPObserver(
-                ctx,
-                nwSession: impl,
-                options: .init(
-                    maxDatagrams: options.maxUDPDatagrams
+            if options.withNetworkFramework {
+                let impl = NWConnection(to: endpoint.nwEndpoint, using: .udp)
+                return NESocketObserver(ctx, nwConnection: impl, options: .init())
+            } else {
+                let impl = provider.createUDPSession(
+                    to: endpoint.nwHostEndpoint,
+                    from: nil
                 )
-            )
+                return NEUDPObserver(
+                    ctx,
+                    nwSession: impl,
+                    options: .init(
+                        maxDatagrams: options.maxUDPDatagrams
+                    )
+                )
+            }
 
         case .tcp:
-            let impl = provider.createTCPConnection(to: nwEndpoint, enableTLS: false, tlsParameters: nil, delegate: nil)
-            return NETCPObserver(
-                ctx,
-                nwConnection: impl,
-                options: .init(
-                    minLength: options.minTCPLength,
-                    maxLength: options.maxTCPLength
+            if options.withNetworkFramework {
+                let impl = NWConnection(to: endpoint.nwEndpoint, using: .tcp)
+                return NESocketObserver(ctx, nwConnection: impl, options: .init())
+            } else {
+                let impl = provider.createTCPConnection(
+                    to: endpoint.nwHostEndpoint,
+                    enableTLS: false,
+                    tlsParameters: nil,
+                    delegate: nil
                 )
-            )
+                return NETCPObserver(
+                    ctx,
+                    nwConnection: impl,
+                    options: .init(
+                        minLength: options.minTCPLength,
+                        maxLength: options.maxTCPLength
+                    )
+                )
+            }
         }
     }
 
@@ -78,7 +98,12 @@ private extension NEInterfaceFactory {
 }
 
 private extension ExtendedEndpoint {
-    var nwEndpoint: NWHostEndpoint {
+    var nwEndpoint: Network.NWEndpoint {
+        .hostPort(host: .init(address.rawValue), port: .init(integerLiteral: proto.port))
+    }
+
+    @available(*, deprecated, message: "NetworkExtension UDP/TCP sockets were removed in Swift 6")
+    var nwHostEndpoint: NWHostEndpoint {
         NWHostEndpoint(hostname: address.rawValue, port: proto.port.description)
     }
 }

--- a/Sources/Vendors/AppleNE/Connection/NEInterfaceFactory.swift
+++ b/Sources/Vendors/AppleNE/Connection/NEInterfaceFactory.swift
@@ -46,8 +46,8 @@ public final class NEInterfaceFactory: NetworkInterfaceFactory {
                 let impl = NWConnection(to: endpoint.nwEndpoint, using: .udp)
                 let socketOptions = NESocketObserver.Options(
                     proto: .udp,
-                    minLength: 1,
-                    maxLength: options.maxTCPLength
+                    minLength: 0,   // unused
+                    maxLength: 0    // unused
                 )
                 return NESocketObserver(ctx, nwConnection: impl, options: socketOptions)
             } else {

--- a/Sources/Vendors/AppleNE/Connection/NEInterfaceFactory.swift
+++ b/Sources/Vendors/AppleNE/Connection/NEInterfaceFactory.swift
@@ -46,7 +46,7 @@ public final class NEInterfaceFactory: NetworkInterfaceFactory {
                 let impl = NWConnection(to: endpoint.nwEndpoint, using: .udp)
                 let socketOptions = NESocketObserver.Options(
                     proto: .udp,
-                    minLength: options.minTCPLength,
+                    minLength: 1,
                     maxLength: options.maxTCPLength
                 )
                 return NESocketObserver(ctx, nwConnection: impl, options: socketOptions)

--- a/Sources/Vendors/AppleNE/Connection/NEInterfaceFactory.swift
+++ b/Sources/Vendors/AppleNE/Connection/NEInterfaceFactory.swift
@@ -44,7 +44,12 @@ public final class NEInterfaceFactory: NetworkInterfaceFactory {
         case .udp:
             if options.withNetworkFramework {
                 let impl = NWConnection(to: endpoint.nwEndpoint, using: .udp)
-                return NESocketObserver(ctx, nwConnection: impl, options: .init())
+                let socketOptions = NESocketObserver.Options(
+                    proto: .udp,
+                    minLength: options.minTCPLength,
+                    maxLength: options.maxTCPLength
+                )
+                return NESocketObserver(ctx, nwConnection: impl, options: socketOptions)
             } else {
                 let impl = provider.createUDPSession(
                     to: endpoint.nwHostEndpoint,
@@ -62,7 +67,12 @@ public final class NEInterfaceFactory: NetworkInterfaceFactory {
         case .tcp:
             if options.withNetworkFramework {
                 let impl = NWConnection(to: endpoint.nwEndpoint, using: .tcp)
-                return NESocketObserver(ctx, nwConnection: impl, options: .init())
+                let socketOptions = NESocketObserver.Options(
+                    proto: .tcp,
+                    minLength: options.minTCPLength,
+                    maxLength: options.maxTCPLength
+                )
+                return NESocketObserver(ctx, nwConnection: impl, options: socketOptions)
             } else {
                 let impl = provider.createTCPConnection(
                     to: endpoint.nwHostEndpoint,

--- a/Sources/Vendors/AppleNE/Connection/NESocket.swift
+++ b/Sources/Vendors/AppleNE/Connection/NESocket.swift
@@ -109,8 +109,6 @@ private actor NESocket: LinkInterface {
 
     private let betterPathStream: PassthroughStream<Void>
 
-    private let writeComplete: Bool
-
     private var writeBlock: (@Sendable ([Data]) async throws -> Void)?
 
     init(
@@ -127,7 +125,6 @@ private actor NESocket: LinkInterface {
 
         switch remoteProtocol.socketType.plainType {
         case .udp:
-            writeComplete = true
             writeBlock = { [weak self] in
                 guard let self else { return }
                 // can this be parallelized with TaskGroup?
@@ -136,7 +133,6 @@ private actor NESocket: LinkInterface {
                 }
             }
         case .tcp:
-            writeComplete = false
             writeBlock = { [weak self] in
                 guard let self else { return }
                 let joinedPacket = Data($0.joined())
@@ -214,7 +210,6 @@ private extension NESocket {
             try await withCheckedThrowingContinuation { continuation in
                 nwConnection.send(
                     content: packet,
-                    isComplete: writeComplete,
                     completion: .contentProcessed { error in
                         if let error {
                             continuation.resume(throwing: error)

--- a/Sources/Vendors/AppleNE/Connection/NESocket.swift
+++ b/Sources/Vendors/AppleNE/Connection/NESocket.swift
@@ -53,8 +53,10 @@ public final class NESocketObserver: LinkObserver {
         case .hostPort(let host, let port):
             switch host {
             case .ipv4(let addr):
+                // XXX: this might be unsafe
                 rawAddress = addr.debugDescription
             case .ipv6(let addr):
+                // XXX: this might be unsafe
                 rawAddress = addr.debugDescription
             case .name(let name, let interface):
                 rawAddress = name

--- a/Sources/Vendors/AppleNE/Connection/NESocket.swift
+++ b/Sources/Vendors/AppleNE/Connection/NESocket.swift
@@ -33,7 +33,7 @@ public final class NESocketObserver: LinkObserver {
 
     public func waitForActivity(timeout: Int) async throws -> LinkInterface {
         let cancellationTask = Task {
-            try await Task.sleep(for: .milliseconds(timeout))
+            try await Task.sleep(milliseconds: timeout)
             guard !Task.isCancelled else { return }
             nwConnection.cancel()
         }

--- a/Sources/Vendors/AppleNE/Connection/NESocket.swift
+++ b/Sources/Vendors/AppleNE/Connection/NESocket.swift
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: 2025 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+import NetworkExtension
+import PartoutCore
+
+/// Implementation of a ``/PartoutCore/LinkObserver`` via `NWTCPConnection`.
+public final class NESocketObserver: LinkObserver {
+    public struct Options: Sendable {
+        public let proto: IPSocketType
+
+        public let minLength: Int
+
+        public let maxLength: Int
+    }
+
+    private let ctx: PartoutLoggerContext
+
+    private let nwConnection: NWConnection
+
+    private let options: Options
+
+    private var readyContinuation: CheckedContinuation<Void, Error>?
+
+    public init(_ ctx: PartoutLoggerContext, nwConnection: NWConnection, options: Options) {
+        self.ctx = ctx
+        self.nwConnection = nwConnection
+        self.options = options
+
+        nwConnection.stateUpdateHandler = onStateUpdate
+    }
+
+    public func waitForActivity(timeout: Int) async throws -> LinkInterface {
+        let cancellationTask = Task {
+            try await Task.sleep(for: .milliseconds(timeout))
+            guard !Task.isCancelled else { return }
+            nwConnection.cancel()
+        }
+        try await withCheckedThrowingContinuation { [weak self] continuation in
+            guard let self else { return }
+            readyContinuation = continuation
+            nwConnection.start(queue: .global())
+        }
+        cancellationTask.cancel()
+
+        let rawAddress: String
+        let rawPort: UInt16
+        switch nwConnection.endpoint {
+        case .hostPort(let host, let port):
+            switch host {
+            case .ipv4(let addr):
+                rawAddress = addr.debugDescription
+            case .ipv6(let addr):
+                rawAddress = addr.debugDescription
+            case .name(let name, let interface):
+                rawAddress = name
+            default:
+                throw PartoutError(.connectionNotStarted)
+            }
+            rawPort = port.rawValue
+        default:
+            throw PartoutError(.connectionNotStarted)
+        }
+
+        return NESocket(
+            nwConnection: nwConnection,
+            options: options,
+            remoteAddress: rawAddress,
+            remoteProtocol: EndpointProtocol(
+                options.proto,
+                rawPort
+            )
+        )
+    }
+}
+
+private extension NESocketObserver {
+    func onStateUpdate(_ state: NWConnection.State) {
+        pp_log(ctx, .ne, .info, "Socket state is \(state.debugDescription)")
+        switch state {
+        case .ready:
+            readyContinuation?.resume()
+            readyContinuation = nil
+        case .failed(let error):
+            readyContinuation?.resume(throwing: error)
+        case .waiting(let error):
+            readyContinuation?.resume(throwing: error)
+        case .cancelled:
+            readyContinuation?.resume(throwing: PartoutError(.operationCancelled))
+        case .preparing, .setup:
+            break
+        @unknown default:
+            readyContinuation?.resume(throwing: PartoutError(.unhandled))
+        }
+    }
+}
+
+// MARK: - NESocket
+
+private actor NESocket: LinkInterface {
+    private nonisolated let nwConnection: NWConnection
+
+    private let options: NESocketObserver.Options
+
+    let remoteAddress: String
+
+    let remoteProtocol: EndpointProtocol
+
+    private let betterPathStream: PassthroughStream<Void>
+
+    private let writeComplete: Bool
+
+    private var writeBlock: (@Sendable ([Data]) async throws -> Void)?
+
+    init(
+        nwConnection: NWConnection,
+        options: NESocketObserver.Options,
+        remoteAddress: String,
+        remoteProtocol: EndpointProtocol
+    ) {
+        self.nwConnection = nwConnection
+        self.options = options
+        self.remoteAddress = remoteAddress
+        self.remoteProtocol = remoteProtocol
+        betterPathStream = PassthroughStream()
+
+        switch remoteProtocol.socketType.plainType {
+        case .udp:
+            writeComplete = true
+            writeBlock = { [weak self] in
+                guard let self else { return }
+                // can this be parallelized with TaskGroup?
+                for p in $0 {
+                    try await asyncWritePacket(p)
+                }
+            }
+        case .tcp:
+            writeComplete = false
+            writeBlock = { [weak self] in
+                guard let self else { return }
+                let joinedPacket = Data($0.joined())
+                try await asyncWritePacket(joinedPacket)
+            }
+        }
+        nwConnection.betterPathUpdateHandler = { isBetter in
+            Task { [weak self] in
+                await self?.onBetterPath(isBetter)
+            }
+        }
+    }
+}
+
+// MARK: LinkInterface
+
+extension NESocket {
+    nonisolated var hasBetterPath: AsyncStream<Void> {
+        betterPathStream.subscribe()
+    }
+
+    func onBetterPath(_ isBetter: Bool) {
+        guard isBetter else { return }
+        betterPathStream.send()
+    }
+
+    nonisolated func upgraded() -> LinkInterface {
+        Self(
+            nwConnection: NWConnection(
+                to: nwConnection.endpoint,
+                using: nwConnection.parameters
+            ),
+            options: options,
+            remoteAddress: remoteAddress,
+            remoteProtocol: remoteProtocol
+        )
+    }
+
+    nonisolated func shutdown() {
+        nwConnection.cancel()
+    }
+}
+
+// MARK: IOInterface
+
+extension NESocket {
+    public nonisolated func setReadHandler(_ handler: @escaping ([Data]?, Error?) -> Void) {
+        loopReadPackets(handler)
+    }
+
+    public func writePackets(_ packets: [Data]) async throws {
+        guard !packets.isEmpty else {
+            return
+        }
+        try await writeBlock?(packets)
+    }
+}
+
+private extension NESocket {
+    nonisolated func loopReadPackets(_ handler: @escaping ([Data]?, Error?) -> Void) {
+
+        // WARNING: runs in Network.framework queue
+        nwConnection.receiveMessage { [weak self] data, context, isComplete, error in
+            handler(data.map { [$0] }, error)
+
+            // repeat until failure
+            if error == nil {
+                self?.loopReadPackets(handler)
+            }
+        }
+    }
+
+    func asyncWritePacket(_ packet: Data) async throws {
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                nwConnection.send(
+                    content: packet,
+                    isComplete: writeComplete,
+                    completion: .contentProcessed { error in
+                        if let error {
+                            continuation.resume(throwing: error)
+                            return
+                        }
+                        continuation.resume()
+                    }
+                )
+            }
+        } onCancel: {
+            nwConnection.cancel()
+        }
+    }
+}

--- a/Sources/Vendors/AppleNE/Connection/NETCPSocket.swift
+++ b/Sources/Vendors/AppleNE/Connection/NETCPSocket.swift
@@ -7,6 +7,7 @@ import NetworkExtension
 import PartoutCore
 
 /// Implementation of a ``/PartoutCore/LinkObserver`` via `NWTCPConnection`.
+@available(*, deprecated, message: "Use NESocketObserver")
 public final class NETCPObserver: LinkObserver {
     public struct Options: Sendable {
         public let minLength: Int

--- a/Sources/Vendors/AppleNE/Connection/NEUDPSocket.swift
+++ b/Sources/Vendors/AppleNE/Connection/NEUDPSocket.swift
@@ -7,6 +7,7 @@ import NetworkExtension
 import PartoutCore
 
 /// Implementation of a ``/PartoutCore/LinkObserver`` via `NWUDPSession`.
+@available(*, deprecated, message: "Use NESocketObserver")
 public final class NEUDPObserver: LinkObserver {
     public struct Options: Sendable {
         public let maxDatagrams: Int

--- a/Sources/Vendors/AppleNE/Connection/ValueObserver.swift
+++ b/Sources/Vendors/AppleNE/Connection/ValueObserver.swift
@@ -6,7 +6,7 @@ import Foundation
 import PartoutCore
 
 /// Observes KVO updates asynchronously.
-@available(*, deprecated, message: "Required by deprecated NEUDPSocket and NETCPSocket. Use NESocket instead")
+@available(*, deprecated, message: "Required by the deprecated NEUDPObserver and NETCPObserver. Use NESocketObserver instead")
 actor ValueObserver<O> where O: NSObject {
     private weak var subject: O?
 

--- a/Sources/Vendors/AppleNE/Connection/ValueObserver.swift
+++ b/Sources/Vendors/AppleNE/Connection/ValueObserver.swift
@@ -6,6 +6,7 @@ import Foundation
 import PartoutCore
 
 /// Observes KVO updates asynchronously.
+@available(*, deprecated, message: "Unstable, use NESocketObserver")
 actor ValueObserver<O> where O: NSObject {
     private weak var subject: O?
 

--- a/Sources/Vendors/AppleNE/Connection/ValueObserver.swift
+++ b/Sources/Vendors/AppleNE/Connection/ValueObserver.swift
@@ -6,7 +6,7 @@ import Foundation
 import PartoutCore
 
 /// Observes KVO updates asynchronously.
-@available(*, deprecated, message: "Unstable, use NESocketObserver")
+@available(*, deprecated, message: "Required by deprecated NEUDPSocket and NETCPSocket. Use NESocket instead")
 actor ValueObserver<O> where O: NSObject {
     private weak var subject: O?
 

--- a/Sources/Vendors/AppleNE/Extensions/NWConnectionState+Description.swift
+++ b/Sources/Vendors/AppleNE/Extensions/NWConnectionState+Description.swift
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025 Davide De Rosa
+//
+// SPDX-License-Identifier: GPL-3.0
+
+import Foundation
+import NetworkExtension
+
+extension NWConnection.State: @retroactive CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .cancelled: return "cancelled"
+        case .failed(let error): return "failed (\(error.localizedDescription))"
+        case .preparing: return "preparing"
+        case .ready: return "ready"
+        case .setup: return "setup"
+        case .waiting(let error): return "waiting (\(error.localizedDescription))"
+        @unknown default: return "???"
+        }
+    }
+}


### PR DESCRIPTION
Apple finally deprecated [NWUDPSession](https://developer.apple.com/documentation/networkextension/nwudpsession) and [NWTCPConnection](https://developer.apple.com/documentation/networkextension/nwtcpconnection). Time to move on and use the more comprehensive [NWConnection](https://developer.apple.com/documentation/network/nwconnection). The deprecated classes are not available at all in Swift 6 mode.

Switch to the new implementation with the `.withNetworkFramework` option of NEInterfaceFactory.Options (opt-in).